### PR TITLE
Fix penalty in print.rgcca

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -6,7 +6,7 @@ check_blockx <- function(x, y, blocks){
     )
     exit_code = 133
     x <- check_integer(x, y, max = length(blocks), exit_code = exit_code,
-                       message = message)
+                       max_message = message)
     return(x)
 }
 
@@ -113,7 +113,8 @@ check_file <- function(f) {
 # check_integer(c(1:2))
 # check_integer("x", c(0, 0), type = "vector")
 check_integer <- function(x, y = x, type = "scalar", float = FALSE, min = 1,
-                          max = Inf, message = NULL, exit_code = NULL) {
+                          max = Inf, max_message = NULL, exit_code = NULL,
+                          min_message = NULL) {
 
     if (is.null(y))
         y <- x
@@ -144,11 +145,15 @@ check_integer <- function(x, y = x, type = "scalar", float = FALSE, min = 1,
     }
 
     if (any(y < min))
+      if (!is.null(min_message)) {
+        stop_rgcca(min_message, exit_code = exit_code)
+      } else {
         stop_rgcca(paste0(x, " should be higher than or equal to ", min, "."))
+      }
 
     if (any(y > max))
-      if (!is.null(message)) {
-        stop_rgcca(message, exit_code = exit_code)
+      if (!is.null(max_message)) {
+        stop_rgcca(max_message, exit_code = exit_code)
       } else {
         stop_rgcca(paste0(x, " should be lower than or equal to ", max, "."))
       }
@@ -226,7 +231,7 @@ check_ncomp <- function(ncomp, blocks, min = 1) {
                          NCOL(blocks[[x]]),
                          " (that is the number of variables of block ", x, ")."
             )
-            y <- check_integer("ncomp", ncomp[x], min = min, message = msg,
+            y <- check_integer("ncomp", ncomp[x], min = min, max_message = msg,
                                max = NCOL(blocks[[x]]), exit_code = 126)
             return(y)
         }
@@ -346,7 +351,7 @@ check_size_blocks <- function(blocks, x, y = x) {
                 dim_type ,
                 " (actually ",
                 dim_y,
-                ") than the number of blocks (",
+                ") as the number of blocks (",
                 length(blocks),
                 ")."
             ),
@@ -366,39 +371,44 @@ check_size_file <- function(filename) {
         message("File loading in progress ...")
 }
 
-check_spars <- function(blocks, tau, method = "rgcca") {
-    # sparsity : A vector of integer giving the sparsity parameter for SGCCA (sparsity)
-    # Stop the program if at least one sparsity parameter is not in the required interval
-    if (tolower(method) == "sgcca") {
-        tau <- elongate_arg(tau, blocks)
-        check_size_blocks(blocks, "sparsity", tau)
-        #the minimum value avalaible
-        min_sparsity <- lapply(blocks, function(x) 1 / sqrt(NCOL(x)))
+check_penalty <- function(penalty, blocks, method = "rgcca", superblock = F) {
+  if (superblock) {
+    blocks[[length(blocks) + 1]] <- Reduce(cbind,blocks)
+    names(blocks)[length(blocks)] = "superblock"
+  }
+  penalty <- elongate_arg(penalty, blocks)
+  name = ifelse(method == "rgcca", "tau", "sparsity")
+  check_size_blocks(blocks, name, penalty)
+  penalty1 <- penalty
 
-        # Check sparsity varying between 1/sqrt(pj) and 1
-        tau <- mapply(
-            function(x, y) {
-                x <- check_integer("sparsity", x, float = TRUE, min = 0, max = 1)
-                if (x < y)
-                    stop_rgcca(
-                        paste0(
-                            "Sparsity parameter equals to ",
-                            x,
-                            ". For SGCCA, it must be greater than 1/sqrt(number_column) (i.e., ",
-                            toString(unlist(
-                                lapply(min_sparsity, function(x)
-                                    ceiling(x * 100) / 100)
-                            )), ")."
-                        ),
-                        exit_code = 132
-                    )
-                else
-                    x
-            }, tau, min_sparsity)
-    }
+  is_matrix = is(penalty, "matrix")
 
-    invisible(tau)
+  # Check value of each penalty
+  if (method == "rgcca") penalty <- sapply(penalty, check_tau, USE.NAMES = F)
+  if (method == "sgcca") {
+    if (is_matrix) divider = NROW(penalty1)
+    else divider = 1
+    penalty <- sapply(
+      seq(length(penalty)),
+      function(x) check_spars(penalty[x], blocks[[1 + (x - 1) / divider]]))
+  }
+
+  if (is(penalty1, "matrix"))
+    penalty <- matrix(penalty, NROW(penalty1), NCOL(penalty1))
+
+  return(penalty)
 }
+
+check_spars <- function(sparsity, block) {
+  min_sparsity <- 1 / sqrt(NCOL(block))
+  min_message <- paste0("Sparsity parameter equals to ", sparsity,
+                        ". For SGCCA, it must be greater than ",
+                        "1/sqrt(number_column) (i.e., ", min_sparsity, ").")
+  sparsity <- check_integer("sparsity", sparsity, float = TRUE,
+                            min = min_sparsity, max = 1, min_message = min_message)
+  invisible(sparsity)
+}
+
 # #' @export
 check_superblock <- function(is_supervised = NULL, is_superblock = NULL, verbose = TRUE) {
     if (!is.null(is_supervised)) {
@@ -412,34 +422,9 @@ check_superblock <- function(is_supervised = NULL, is_superblock = NULL, verbose
     }else
         return(isTRUE(is_superblock))
 }
-check_tau <- function(tau, blocks, method = "rgcca", superblock = FALSE) {
-    if (superblock) {
-      blocks[[length(blocks) + 1]] <- Reduce(cbind,blocks)
-      names(blocks)[length(blocks)] = "superblock"
-    }
-    tau <- elongate_arg(tau, blocks)
-    check_size_blocks(blocks, "tau", tau)
-    msg <- "tau should be comprise between 0 and 1 or should be set 'optimal'
-    for automatic setting"
-    tau1 <- tau
-    tryCatch({
-        # Check value of each tau
-        tau <- sapply(
-            seq(length(tau)),
-            function(x) {
-                if (is.na(tau[x]) || tau[x] != "optimal") {
-                    y <- check_integer("tau", tau[x], float = TRUE, min = 0, max = 1)
-                }else
-                    tau[x]
-            })
-
-        if (is(tau1, "matrix"))
-            tau <- matrix(tau, NROW(tau1), NCOL(tau1))
-        tau <- check_spars(blocks, tau, method)
-
-        return(tau)
-
-    }, warning = function(w)
-        stop_rgcca(msg, exit_code = 131)
-    )
+check_tau <- function(tau) {
+  if (is.na(tau) || tau != "optimal") {
+    tau <- check_integer("tau", tau, float = TRUE, min = 0, max = 1)
+  }
+  invisible(tau)
 }

--- a/R/print.rgcca.R
+++ b/R/print.rgcca.R
@@ -59,7 +59,7 @@ print.rgcca <- function(x,...)
   if(x$call$method %in% c("rgcca"))
   {
      param="regularization"
-    if(!is.matrix(x$tau))
+    if(!is.matrix(x$call$tau))
     {
         for (i in 1:NCOL(x$call$connection))
         {
@@ -71,28 +71,29 @@ print.rgcca <- function(x,...)
     {
 
         cat("The",param,"parameters used were: \n")
-        print(round(x$tau,4),...)
+        print(round(x$call$tau,4),...)
     }
   }
   if(x$call$method %in% c("sgcca"))
   {
+      nb_selected_var = lapply(x$a, function(a) apply(a, 2, function(l) sum(l != 0)))
       param="sparsity"
-      if(!is.matrix(x$sparsity))
+      if(!is.matrix(x$call$sparsity))
       {
           for (i in 1:NCOL(x$call$connection)) {
               sparsity <- x$call$sparsity[i]
 
               cat("The",param,"parameter used for",names(x$call$blocks)[i], "was:",
-                  sparsity, fill = TRUE)
+                  sparsity, "(with", paste(nb_selected_var[[i]], collapse = ", "),
+                  "variables selected)", fill = TRUE)
           }
       }
       else
       {
-          for (i in 1:NCOL(x$call$connection))
-        {
           cat("The",param,"parameters used were: \n")
-          print(round(x$sparsity,4),...)
-         }
+          print(round(x$call$sparsity,4),...)
+          cat("The number of selected variables were: \n")
+          print(do.call(cbind, nb_selected_var))
       }
   }
 }

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -328,7 +328,7 @@ rgcca <- function(blocks, method = "rgcca",
     }
 
 
-    opt$penalty <- check_tau(opt$penalty, opt$blocks, method)
+    opt$penalty <- check_penalty(opt$penalty, opt$blocks, method)
     opt$ncomp <- check_ncomp(opt$ncomp, opt$blocks)
 
     warn_on <- FALSE

--- a/R/rgcca_cv.r
+++ b/R/rgcca_cv.r
@@ -158,14 +158,14 @@ rgcca_cv=function( blocks,
         else{
             if ("data.frame"%in%class(par_value) ||  "matrix"%in% class(par_value))
             {
-                par_value <- t(sapply(seq(NROW(par_value)), function(x) check_tau(par_value[x, ], blocks, method = method)))
+                par_value <- t(sapply(seq(NROW(par_value)), function(x) check_penalty(par_value[x, ], blocks, method = method)))
 
             }
             else
             {
                 if (any(par_value < min_spars))
                     stop_rgcca(paste0("par_value should be upper than : ", paste0(round(min_spars, 2), collapse = ",")))
-                par_value <- check_tau(par_value, blocks, method = method)
+                par_value <- check_penalty(par_value, blocks, method = method)
                 par_value <- set_spars(max = par_value)
             }
         }

--- a/R/rgcca_permutation.R
+++ b/R/rgcca_permutation.R
@@ -310,7 +310,7 @@ rgcca_permutation <- function(blocks, par_type, par_value = NULL,
         {
           if(par_type=="tau"){
             par_value <- t(sapply(seq(NROW(par_value)),
-                                  function(x) check_tau(par_value[x, ],
+                                  function(x) check_penalty(par_value[x, ],
                                                         blocks,
                                                         method = method,
                                                         superblock = superblock)
@@ -324,7 +324,7 @@ rgcca_permutation <- function(blocks, par_type, par_value = NULL,
             stop_rgcca(paste0("par_value should be upper than : ",
                                   paste0(round(min_spars, 2), collapse = ",")))
           if(par_type == "tau"){
-            par_value <- check_tau(par_value, blocks, method = method,
+            par_value <- check_penalty(par_value, blocks, method = method,
                                      superblock = superblock)
             par_value <- set_spars(max = par_value)
           }

--- a/tests/testthat/test_checks.r
+++ b/tests/testthat/test_checks.r
@@ -102,7 +102,7 @@ test_that("check_connection raises an error if the dimensions of C do not
           match the number of blocks", {
   expect_error(check_connection(diag(2), blocks),
                paste0("connection matrix should have the same number of ",
-                      "columns (actually 2) than the number of blocks (3)."),
+                      "columns (actually 2) as the number of blocks (3)."),
                fixed = TRUE)
 })
 test_that("check_connection raises an error if the dimnames of C do not match
@@ -234,7 +234,7 @@ test_that("check_ncomp raises an error if blocks and ncomp have different
           lengths and length of ncomp is greater than 1", {
             expect_error(check_ncomp(c(2, 2), blocks),
                          paste0("ncomp should have the same size (actually 2) ",
-                                "than the number of blocks (3)."),
+                                "as the number of blocks (3)."),
                          fixed = TRUE)
           })
 test_that("check_ncomp raises an error if any element of ncomp is greater than
@@ -265,14 +265,14 @@ test_that("check_size_blocks raises an error when number of columns of x does
           not match length of blocks", {
             expect_error(check_size_blocks(blocks, "x", diag(2)),
                          paste0("x should have the same number of columns",
-                                " (actually 2) than the number of blocks (3)."),
+                                " (actually 2) as the number of blocks (3)."),
                          fixed = TRUE)
           })
 test_that("check_size_blocks raises an error when size of x does
           not match length of blocks", {
             expect_error(check_size_blocks(blocks, "x", c(2, 2)),
                          paste0("x should have the same size (actually 2) ",
-                                "than the number of blocks (3)."),
+                                "as the number of blocks (3)."),
                          fixed = TRUE)
           })
 test_that("check_size_blocks passes when x is valid", {
@@ -282,56 +282,67 @@ test_that("check_size_blocks passes when x is valid", {
 
 # Test check_size_file
 
-# Test check_spars
-test_that("check_spars raises an error if blocks and tau have different
-          lengths and length of tau is greater than 1", {
-            expect_error(check_spars(blocks, c(1, 1), method = "sgcca"),
-                         paste0("sparsity should have the same size ",
-                                "(actually 2) than the number of blocks (3)."),
+# Test check_penalty
+test_that("check_penalty raises an error if blocks and penalty have different
+          lengths and length of penalty is greater than 1", {
+            expect_error(check_penalty(c(1, 1), blocks),
+                         paste0("tau should have the same size ",
+                                "(actually 2) as the number of blocks (3)."),
                          fixed = TRUE)
           })
-test_that("check_spars raises an error if any element of tau is lower than
-          the inverse of the square root of the number of variables in the
+test_that("check_penalty raises an error if any element of sparsity is lower
+          than the inverse of the square root of the number of variables in the
           corresponding block", {
-            min_sparsity <- lapply(blocks, function(x) 1 / sqrt(NCOL(x)))
-            msg = toString(unlist(
-              lapply(min_sparsity, function(x)
-                ceiling(x * 100) / 100)
-            ))
-            expect_error(check_spars(blocks, c(1, 1, 0.2), method = "sgcca"),
+            min_sparsity <- 1 / sqrt(NCOL(blocks[[3]]))
+            expect_error(check_penalty(c(1, 1, 0.2), blocks, method = "sgcca"),
                          paste0("Sparsity parameter equals to 0.2. For SGCCA, ",
                                 "it must be greater than 1/sqrt(number_column)",
-                                " (i.e., ", msg, ")."),
+                                " (i.e., ", min_sparsity, ")."),
                          fixed = TRUE)
           })
-test_that("check_spars raises an error for invalid tau", {
-  expect_error(check_spars(blocks, c(-1, 1, 1), method = "sgcca"))
-  expect_error(check_spars(blocks, c(1, 1, 2), method = "sgcca"))
-  expect_error(check_spars(blocks, c(NA, 1, 1), method = "sgcca"))
+test_that("check_penalty raises an error for invalid penalty", {
+  expect_error(check_penalty(c(-1, 1, 1), blocks, method = "rgcca"))
+  expect_error(check_penalty(c(1, 1, 2), blocks, method = "rgcca"))
+  expect_error(check_penalty(c(NA, 1, 1), blocks, method = "rgcca"))
+  expect_error(check_penalty("toto", blocks, method = "rgcca"))
+  expect_error(check_penalty(c(-1, 1, 1), blocks, method = "sgcca"))
+  expect_error(check_penalty(c(1, 1, 2), blocks, method = "sgcca"))
+  expect_error(check_penalty(c(NA, 1, 1), blocks, method = "sgcca"))
+  expect_error(check_penalty("optimal", blocks, method = "sgcca"))
 })
-test_that("check_spars passes and returns tau when tau is valid", {
-  expect_equal(check_spars(blocks, 1, method = "sgcca"), c(1, 1, 1))
-  expect_equal(check_spars(blocks, c(0.8, 1, 0.5), method = "sgcca"), c(0.8, 1, 0.5))
+test_that("check_penalty passes and returns penalty when penalty is valid", {
+  expect_equal(check_penalty(1, blocks, method = "rgcca"), c(1, 1, 1))
+  expect_equal(check_penalty(c(0.8, 1, 0.5), blocks, method = "rgcca"), c(0.8, 1, 0.5))
+  expect_equal(check_penalty("optimal", blocks, method = "rgcca"), c("optimal", "optimal", "optimal"))
+  expect_equal(check_penalty(matrix(1, 5, 3), blocks, method = "rgcca"), matrix(1, 5, 3))
+  expect_equal(check_penalty(1, blocks, method = "rgcca", superblock = T), c(1, 1, 1, 1))
+  expect_equal(check_penalty(1, blocks, method = "sgcca"), c(1, 1, 1))
+  expect_equal(check_penalty(c(0.8, 1, 0.5), blocks, method = "sgcca"), c(0.8, 1, 0.5))
+  expect_equal(check_penalty(matrix(1, 5, 3), blocks, method = "sgcca"), matrix(1, 5, 3))
+})
+
+# Test check_spars
+test_that("check_spars raises an error for invalid sparsity", {
+  expect_error(check_spars(0.2, blocks[[3]]))
+  expect_error(check_spars(2, blocks[[1]]))
+  expect_error(check_spars(NA, blocks[[2]]))
+})
+test_that("check_spars passes and returns sparsity when sparsity is valid", {
+  expect_equal(check_spars(1, blocks[[1]]), 1)
+  expect_equal(check_spars(0.5, blocks[[3]]), 0.5)
 })
 
 # Test check_superblock
 
 # Test check_tau
-test_that("check_tau raises an error if blocks and tau have different
-          lengths and length of tau is greater than 1", {
-            expect_error(check_tau(c(1, 1), blocks),
-                         paste0("tau should have the same size ",
-                                "(actually 2) than the number of blocks (3)."),
-                         fixed = TRUE)
-          })
 test_that("check_tau raises an error for invalid tau", {
-  expect_error(check_tau(c(-1, 1, 1), blocks))
-  expect_error(check_tau(c(1, 1, 2), blocks))
-  expect_error(check_tau(c(NA, 1, 1), blocks))
+  expect_error(check_tau(-1))
+  expect_error(check_tau(2))
+  expect_error(check_tau(NA))
+  expect_error(check_tau("toto"))
 })
 test_that("check_tau passes and returns tau when tau is valid", {
-  expect_equal(check_tau(1, blocks), c(1, 1, 1))
-  expect_equal(check_tau(c(0.8, 1, 0.5), blocks), c(0.8, 1, 0.5))
-  expect_equal(check_tau(diag(3), blocks), diag(3))
-  expect_equal(check_tau(c(1, 1, 1, 1), blocks, superblock = T), c(1, 1, 1, 1))
+  expect_equal(check_tau(1), 1)
+  expect_equal(check_tau(0.3), 0.3)
+  expect_equal(check_tau("optimal"), "optimal")
 })


### PR DESCRIPTION
- Fix if condition in `print.rgcca` to handle matrices correctly.
- Refactor `check_tau` and `check_spars` with the `check_penalty` function.
- Add number of selected variables when printing SGCCA objects.