### PR TITLE
Superblock deflation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,8 +52,7 @@ Suggests:
     shiny,
     shinyjs,
     testthat,
-    FactoMineR,
-    cluster
+    FactoMineR
 VignetteBuilder: 
     knitr
 biocViews: Visualization, PrincipalComponent, DimensionReduction,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,9 @@ Suggests:
     rmarkdown,
     shiny,
     shinyjs,
-    testthat
+    testthat,
+    FactoMineR,
+    cluster
 VignetteBuilder: 
     knitr
 biocViews: Visualization, PrincipalComponent, DimensionReduction,

--- a/R/checks.R
+++ b/R/checks.R
@@ -221,18 +221,31 @@ check_ncol <- function(x, i_block) {
     }
 }
 
-check_ncomp <- function(ncomp, blocks, min = 1) {
+check_ncomp <- function(ncomp, blocks, min = 1, superblock = FALSE) {
     ncomp <- elongate_arg(ncomp, blocks)
     check_size_blocks(blocks, "ncomp", ncomp)
     ncomp <- sapply(
         seq(length(ncomp)),
         function(x){
-            msg = paste0("ncomp[", x, "] should be lower than ",
-                         NCOL(blocks[[x]]),
-                         " (that is the number of variables of block ", x, ")."
-            )
-            y <- check_integer("ncomp", ncomp[x], min = min, max_message = msg,
+            if(!superblock){
+              msg = paste0("ncomp[", x, "] should be lower than ",
+                            NCOL(blocks[[x]]),
+                            " (i.e. the number of variables for block ", x, ")."
+              )
+              y <- check_integer("ncomp", ncomp[x], min = min, max_message = msg,
                                max = NCOL(blocks[[x]]), exit_code = 126)
+            }else{
+              msg = paste0("The number of global components should be lower than",
+                           NCOL(blocks[[length(blocks)]]),
+                           " (i.e. the number of variables in the superblock.")
+
+              y <- check_integer("ncomp", ncomp[length(blocks)],
+                                 min = min, max_message = msg,
+                                 max = NCOL(blocks[[length(blocks)]]),
+                                 exit_code = 126)
+
+            }
+
             return(y)
         }
     )

--- a/R/checks.R
+++ b/R/checks.R
@@ -222,6 +222,8 @@ check_ncol <- function(x, i_block) {
 }
 
 check_ncomp <- function(ncomp, blocks, min = 1, superblock = FALSE) {
+    if (superblock && length(unique(ncomp)) != 1)
+        stop_rgcca("Specify the number of components only for the superblock or identical for all blocks.")
     ncomp <- elongate_arg(ncomp, blocks)
     check_size_blocks(blocks, "ncomp", ncomp)
     ncomp <- sapply(

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -307,6 +307,7 @@ rgcca <- function(blocks, method = "rgcca",
                               scale = scale,
                               bias = bias,
                               scale_block = scale_block)
+    
     opt$superblock <- check_superblock(response, opt$superblock, !quiet)
     opt$blocks     <- set_superblock(opt$blocks, opt$superblock,
                                      method, !quiet)
@@ -347,7 +348,6 @@ rgcca <- function(blocks, method = "rgcca",
 
     if (warn_on && !quiet)
         message("Analysis in progress ...")
-
     func <- quote(
         gcca(
             blocks = opt$blocks,
@@ -360,7 +360,7 @@ rgcca <- function(blocks, method = "rgcca",
             tol = tol,
             quiet = quiet,
             na.rm = na.rm,
-            superblock=superblock
+            superblock=opt$superblock
         )
     )
 

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -358,25 +358,26 @@ rgcca <- function(blocks, method = "rgcca",
     func[[par]] <- opt$penalty
     func_out <- eval(as.call(func))
 
-    for (i in c("a", "Y")) {
-       names(func_out[[i]]) <- names(opt$blocks)
-        for (j in seq(length(opt$blocks))) {
-            if (NCOL(opt$blocks[[j]]) == 1)
-                row.names(func_out[["a"]][[j]]) <- colnames(opt$blocks[[j]])
-        }
+    for (j in seq(length(opt$blocks))) {
+      rownames(func_out$a[[j]]) = colnames(opt$blocks[[j]])
+      rownames(func_out$Y[[j]]) = rownames(opt$blocks[[j]])
+      colnames(func_out$Y[[j]]) = paste0("comp", seq_len(max(opt$ncomp)))
     }
 
-    if(!opt$superblock){
-      names(func_out[["astar"]]) <- names(opt$blocks)
-      for (j in seq(length(opt$blocks))){
-        if (NCOL(opt$blocks[[j]]) == 1)
-          row.names(func_out[["astar"]][[j]]) <- colnames(opt$blocks[[j]])
-      }
+    func_out$a <- shave(func_out$a, opt$ncomp)
+    func_out$Y <- shave(func_out$Y, opt$ncomp)
+
+    if (!opt$superblock) {
+      for (j in seq(length(opt$blocks)))
+        rownames(func_out$astar[[j]]) = colnames(opt$blocks[[j]])
+      func_out$astar <- shave(func_out$astar, opt$ncomp)
     }else{
-      if (NCOL(opt$blocks[[length(opt$blocks)]]) == 1)
-        row.names(func_out[["astar"]][[length(opt$blocks)]]) <-
-          colnames(opt$blocks[[length(opt$blocks)]])
+      rownames(func_out$astar) <- colnames(opt$blocks[[length(opt$blocks)]])
     }
+
+    names(func_out$a) <- names(opt$blocks)
+    names(func_out$Y) <- names(opt$blocks)
+    if (!opt$superblock) names(func_out$astar) <- names(opt$blocks)
 
     names(func_out$AVE$AVE_X) <- names(opt$blocks)
 

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -238,12 +238,6 @@ rgcca <- function(blocks, method = "rgcca",
     if (!missing(response) && missing(superblock))
         superblock <- FALSE
 
-    if ((superblock ||
-         tolower(method)%in%c("gcca", "maxvar", "maxvar-b", "cpca-1",
-                     "cpca-2", "maxvar-a", "mcoa","cpca-4", "hpca"))&&
-        length(unique(ncomp)) != 1)
-      stop_rgcca("Specify the number of components only for the superblock or identical for all blocks.")
-
     if (tolower(method) %in% c("sgcca", "spca", "spls")) {
       if (!missing(tau) && missing(sparsity))
            stop_rgcca(paste0("sparsity parameters required for ",
@@ -338,7 +332,7 @@ rgcca <- function(blocks, method = "rgcca",
 
 
     opt$penalty <- check_penalty(opt$penalty, opt$blocks, method)
-    opt$ncomp <- check_ncomp(opt$ncomp, opt$blocks, opt$superblock)
+    opt$ncomp <- check_ncomp(opt$ncomp, opt$blocks, superblock = opt$superblock)
 
     warn_on <- FALSE
     if(method=="pca") opt$superblock=FALSE

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -359,7 +359,8 @@ rgcca <- function(blocks, method = "rgcca",
             bias = bias,
             tol = tol,
             quiet = quiet,
-            na.rm = na.rm
+            na.rm = na.rm,
+            superblock=superblock
         )
     )
 

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -47,9 +47,10 @@
 #' @param scale Logical value indicating if blocks are standardized.
 #' @param scale_block Value indicating if each block is divided by
 #' a constant value. If TRUE or "inertia", each block is divided by the
-#' Frobenius norm of its empirical covariance matrix. If "lambda1", each block
-#' is divided by the square root of the highest eigenvalue of its empirical
-#' covariance matrix. Otherwise the blocks are not scaled. If standardization is
+#' sum of eigenvalues of its empirical covariance matrix.
+#' If "lambda1", each block is divided by the square root of the highest
+#' eigenvalue of its empirical covariance matrix.
+#' Otherwise the blocks are not scaled. If standardization is
 #' applied (scale = TRUE), the block scaling is applied on the result of the
 #' standardization.
 #' @param NA_method  Character string corresponding to the method used for

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -186,11 +186,12 @@ rgcca <- function(blocks, method = "rgcca",
                   scale = TRUE, scale_block = TRUE,
                   connection = 1 - diag(length(blocks)),
                   scheme = "factorial",
-                  ncomp = rep(1, length(blocks)),
+                  ncomp = rep(1,length(blocks)),
                   tau = rep(1, length(blocks)),
                   sparsity = rep(1, length(blocks)),
                   init = "svd", bias = TRUE, tol = 1e-08,
-                  response = NULL, superblock = FALSE,
+                  response = NULL, 
+                  superblock = FALSE,
                   NA_method = "nipals", verbose = FALSE, quiet = TRUE){
 
     if(class(blocks)=="permutation")
@@ -224,6 +225,7 @@ rgcca <- function(blocks, method = "rgcca",
           sparsity=blocks$bestpenalties
         blocks<-blocks$call$blocks
     }
+
 
     if(length(blocks) == 1){
         if(method != "pca")
@@ -277,8 +279,18 @@ rgcca <- function(blocks, method = "rgcca",
         check_boolean(i, get(i))
 
     penalty <- elongate_arg(penalty, blocks)
-    ncomp <- elongate_arg(ncomp, blocks)
+    
 
+    
+    # if(superblock||method%in%c( "maxvar", "maxvar-b",
+    # "cpca-1", "cpca-2", "maxvar-a", "mcoa",
+    # "cpca-4", "hpca"))
+    # {
+    #   if(length(ncomp)!=1){stop("Please enter in ncomp an integer corresponding to the number of components required in the superblock.")}
+    #   ncomp=c(lapply(blocks,ncol),ncomp)
+    # }
+    ncomp <- elongate_arg(ncomp, blocks)
+    
     opt <- select_analysis(
         blocks = blocks,
         connection = connection,
@@ -290,6 +302,9 @@ rgcca <- function(blocks, method = "rgcca",
         quiet = quiet,
         response = response
     )
+  
+    
+   
     raw = blocks
    if(!is.null(response))
    {
@@ -340,7 +355,9 @@ rgcca <- function(blocks, method = "rgcca",
     opt$ncomp <- check_ncomp(opt$ncomp, opt$blocks)
 
     warn_on <- FALSE
+    if(method=="pca"){opt$superblock=FALSE}
 
+    
     if (any(sapply(opt$blocks, NCOL) > 1000)) {
             # if( (method <-<- "sgcca" && tau > 0.3) || method !<- "sgcca" )
             warn_on <- TRUE

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -190,7 +190,7 @@ rgcca <- function(blocks, method = "rgcca",
                   tau = rep(1, length(blocks)),
                   sparsity = rep(1, length(blocks)),
                   init = "svd", bias = TRUE, tol = 1e-08,
-                  response = NULL, 
+                  response = NULL,
                   superblock = FALSE,
                   NA_method = "nipals", verbose = FALSE, quiet = TRUE){
 
@@ -227,15 +227,7 @@ rgcca <- function(blocks, method = "rgcca",
     }
 
 
-    if(length(blocks) == 1){
-        if(method != "pca")
-        {
-            method = "pca"
-            message("method='rgcca' is not available for one block only and
-                    method was converted to 'pca'.")
-        }
-
-    }
+    if(length(blocks) == 1 && method != "pca") method = "pca"
 
     if (!missing(sparsity) && missing(method))
         method <- "sgcca"
@@ -245,6 +237,12 @@ rgcca <- function(blocks, method = "rgcca",
 
     if (!missing(response) && missing(superblock))
         superblock <- FALSE
+
+    if ((superblock ||
+         tolower(method)%in%c("gcca", "maxvar", "maxvar-b", "cpca-1",
+                     "cpca-2", "maxvar-a", "mcoa","cpca-4", "hpca"))&&
+        length(unique(ncomp)) != 1)
+      stop_rgcca("Specify the number of components only for the superblock or identical for all blocks.")
 
     if (tolower(method) %in% c("sgcca", "spca", "spls")) {
       if (!missing(tau) && missing(sparsity))
@@ -268,29 +266,18 @@ rgcca <- function(blocks, method = "rgcca",
     check_scheme(scheme)
 
   # Check blocks size, add NA for missing subjects
-    blocks = check_blocks(blocks, add_NAlines=TRUE, n=1,
-                          init=TRUE, quiet=quiet)
+    blocks = check_blocks(blocks, add_NAlines = TRUE,
+                          n = 1, init = TRUE, quiet = quiet)
     if (!is.null(response))
         check_blockx("response", response, blocks)
     check_integer("tol", tol, float = TRUE, min = 0)
-
 
     for (i in c("superblock", "verbose", "scale", "bias", "quiet"))
         check_boolean(i, get(i))
 
     penalty <- elongate_arg(penalty, blocks)
-    
-
-    
-    # if(superblock||method%in%c( "maxvar", "maxvar-b",
-    # "cpca-1", "cpca-2", "maxvar-a", "mcoa",
-    # "cpca-4", "hpca"))
-    # {
-    #   if(length(ncomp)!=1){stop("Please enter in ncomp an integer corresponding to the number of components required in the superblock.")}
-    #   ncomp=c(lapply(blocks,ncol),ncomp)
-    # }
     ncomp <- elongate_arg(ncomp, blocks)
-    
+
     opt <- select_analysis(
         blocks = blocks,
         connection = connection,
@@ -302,9 +289,9 @@ rgcca <- function(blocks, method = "rgcca",
         quiet = quiet,
         response = response
     )
-  
-    
-   
+
+
+
     raw = blocks
    if(!is.null(response))
    {
@@ -322,7 +309,7 @@ rgcca <- function(blocks, method = "rgcca",
                               scale = scale,
                               bias = bias,
                               scale_block = scale_block)
-    
+
     opt$superblock <- check_superblock(response, opt$superblock, !quiet)
     opt$blocks     <- set_superblock(opt$blocks, opt$superblock,
                                      method, !quiet)
@@ -338,7 +325,6 @@ rgcca <- function(blocks, method = "rgcca",
         response <- check_blockx("response", response, opt$blocks)
         }
 
-
     if (!is.matrix(opt$connection) || !is.null(response)) {
         opt$connection <- set_connection(
             opt$blocks,
@@ -352,19 +338,13 @@ rgcca <- function(blocks, method = "rgcca",
 
 
     opt$penalty <- check_penalty(opt$penalty, opt$blocks, method)
-    opt$ncomp <- check_ncomp(opt$ncomp, opt$blocks)
+    opt$ncomp <- check_ncomp(opt$ncomp, opt$blocks, opt$superblock)
 
     warn_on <- FALSE
-    if(method=="pca"){opt$superblock=FALSE}
+    if(method=="pca") opt$superblock=FALSE
+    if (any(sapply(opt$blocks, NCOL) > 1000)) warn_on <- TRUE
+    if (warn_on && !quiet)  message("Analysis in progress ...")
 
-    
-    if (any(sapply(opt$blocks, NCOL) > 1000)) {
-            # if( (method <-<- "sgcca" && tau > 0.3) || method !<- "sgcca" )
-            warn_on <- TRUE
-    }
-
-    if (warn_on && !quiet)
-        message("Analysis in progress ...")
     func <- quote(
         gcca(
             blocks = opt$blocks,
@@ -384,13 +364,26 @@ rgcca <- function(blocks, method = "rgcca",
     func[[par]] <- opt$penalty
     func_out <- eval(as.call(func))
 
-    for (i in c("a", "astar", "Y")) {
-        names(func_out[[i]]) <- names(opt$blocks)
+    for (i in c("a", "Y")) {
+       names(func_out[[i]]) <- names(opt$blocks)
         for (j in seq(length(opt$blocks))) {
-            if (i %in%  c("a", "astar") && NCOL(opt$blocks[[j]]) == 1)
-                row.names(func_out[[i]][[j]]) <- colnames(opt$blocks[[j]])
+            if (NCOL(opt$blocks[[j]]) == 1)
+                row.names(func_out[["a"]][[j]]) <- colnames(opt$blocks[[j]])
         }
     }
+
+    if(!opt$superblock){
+      names(func_out[["astar"]]) <- names(opt$blocks)
+      for (j in seq(length(opt$blocks))){
+        if (NCOL(opt$blocks[[j]]) == 1)
+          row.names(func_out[["astar"]][[j]]) <- colnames(opt$blocks[[j]])
+      }
+    }else{
+      if (NCOL(opt$blocks[[length(opt$blocks)]]) == 1)
+        row.names(func_out[["astar"]][[length(opt$blocks)]]) <-
+          colnames(opt$blocks[[length(opt$blocks)]])
+    }
+
     names(func_out$AVE$AVE_X) <- names(opt$blocks)
 
     class(func_out) <- tolower(method)

--- a/R/rgcca.R
+++ b/R/rgcca.R
@@ -45,8 +45,13 @@
 #' @inheritParams sgcca
 #' @inheritParams select_analysis
 #' @param scale Logical value indicating if blocks are standardized.
-#' @param scale_block Logical value indicating if each block is divided by
-#' the square root of its number of variables.
+#' @param scale_block Value indicating if each block is divided by
+#' a constant value. If TRUE or "inertia", each block is divided by the
+#' Frobenius norm of its empirical covariance matrix. If "lambda1", each block
+#' is divided by the square root of the highest eigenvalue of its empirical
+#' covariance matrix. Otherwise the blocks are not scaled. If standardization is
+#' applied (scale = TRUE), the block scaling is applied on the result of the
+#' standardization.
 #' @param NA_method  Character string corresponding to the method used for
 #' handling missing values ("nipals", "complete"). (default: "nipals").
 #' \itemize{
@@ -183,7 +188,7 @@
 #' \code{\link[RGCCA]{rgcca_permutation}}
 #' \code{\link[RGCCA]{rgcca_predict}}
 rgcca <- function(blocks, method = "rgcca",
-                  scale = TRUE, scale_block = TRUE,
+                  scale = TRUE, scale_block = "inertia",
                   connection = 1 - diag(length(blocks)),
                   scheme = "factorial",
                   ncomp = rep(1,length(blocks)),

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -289,11 +289,19 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
       for (b in 1:J) Y[[b]][, n] <- rgcca.result$Y[, b]
       for (b in 1:J) a[[b]][, n] <- rgcca.result$a[[b]]
       
-      
-      for (b in 1:J) astar[[b]][, n] <- rgcca.result$a[[b]] -
+      if(!superblock)
+      {
+        for (b in 1:J) astar[[b]][, n] <- rgcca.result$a[[b]] -
         astar[[b]][, (1:(n - 1)),drop = F] %*%
         drop( t(a[[b]][, n]) %*% P[[b]][, 1:(n - 1), drop = F] )
-      
+      }
+      if(superblock)
+      {
+        for (b in 1:(J-1)){ astar[[b]][, n] <- matrix(NA,nrow(rgcca.result$a[[b]]),ncol(rgcca.result$a[[b]]))}
+        astar[[J]][, n] <- rgcca.result$a[[J]] -
+            astar[[J]][, (1:(n - 1)),drop = F] %*%
+            drop( t(a[[J]][, n]) %*% P[[J]][, 1:(n - 1), drop = F] )
+      }
     
     }
   }

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -57,6 +57,8 @@
 #' (\eqn{1/(n-1)}) estimator of the var/cov (default: bias = TRUE).
 #' @param tol The stopping value for the convergence of the algorithm.
 #' @param na.rm If TRUE, runs rgcca only on available data.
+#' @param superblock TRUE if a superblock is added, FALSE otherwise (deflation
+#' strategy must be adapted when a superblock is used).
 #' @return \item{Y}{A list of \eqn{J} elements. Each element of the list is a
 #' matrix that contains the RGCCA block components for the corresponding block.}
 #' @return \item{a}{A list of \eqn{J} elements. Each element of the list \eqn{a}
@@ -164,7 +166,6 @@
 #' text(fit.rgcca$Y[[1]], fit.rgcca$Y[[2]], rownames(Russett), col = lab)
 #' text(Ytest[, 1], Ytest[, 2], substr(rownames(Russett), 1, 1), col = lab)
 #' @export rgccad
-#' @param superblock TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)
 #' @importFrom grDevices dev.off png rainbow
 #' @importFrom graphics abline axis close.screen grid legend lines par points
 #' rect screen segments split.screen text

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -314,20 +314,6 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
     }
   }
 
-  for (b in seq_len(J)) {
-    rownames(a[[b]]) = colnames(blocks[[b]])
-    rownames(Y[[b]]) = rownames(blocks[[b]])
-    colnames(Y[[b]]) = paste0("comp", seq_len(max(ncomp)))
-  }
-
-  if(!superblock){
-    for (b in seq_len(J)) rownames(astar[[b]]) = colnames(blocks[[b]])
-    astar <- shave(astar, ncomp)
-   }else{
-    rownames(astar) <- colnames(blocks[[J]])
-    astar <- astar
-  }
-
   for (j in seq_len(J)) AVE_X[[j]] = apply(
     cor(blocks[[j]], Y[[j]], use = "pairwise.complete.obs")^2, 2, mean)
 
@@ -336,7 +322,6 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
   for (j in seq_len(max(ncomp)))
     AVE_outer[j] <- sum(pjs * outer[j,])/sum(pjs)
 
-  Y = shave(Y, ncomp)
   AVE_X = shave(AVE_X, ncomp)
 
   AVE <- list(AVE_X = AVE_X, AVE_outer = AVE_outer, AVE_inner = AVE_inner)
@@ -346,8 +331,8 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
     computed_tau = as.vector(computed_tau)
   }
 
-  out <- list(Y = shave(Y, ncomp),
-              a = shave(a, ncomp),
+  out <- list(Y = Y,
+              a = a,
               astar = astar,
               tau = computed_tau,
               crit = crit, primal_dual = primal_dual,

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -246,20 +246,33 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
       if (verbose)
         cat(paste0("Computation of the RGCCA block components #", n, " is under
                  progress...\n"))
-#----------------------
-      J_defl=ifelse(superblock,J,J)
-#----------------------
-      defla.result <- defl.select(rgcca.result$Y, R, ndefl, n - 1, J_defl, na.rm = na.rm)
-      R <- defla.result$resdefl
- 
-#----------------------      
-      if(superblock){
-        R[[J]]=Reduce(cbind,R[1:(J-1)])
-       P[[J]][,n-1]=deflation(as.matrix(R[[J]]), as.matrix(rgcca.result$Y[, J],nrow=nrow(R)), na.rm = na.rm)$p
-      }
-#----------------------
-      for (b in 1:J_defl) P[[b]][, n - 1] <- defla.result$pdefl[[b]]
 
+      if(!superblock)
+      {
+        defla.result <- defl.select(rgcca.result$Y, R, ndefl, n - 1, J, na.rm = na.rm)
+        R <- defla.result$resdefl
+        for (b in 1:J) P[[b]][, n - 1] <- defla.result$pdefl[[b]]
+      }
+  
+
+      if(superblock)
+      {
+        deflation.result.J=deflation(R[[J]], rgcca.result$Y[,J])
+        R[[J]]=deflation.result.J$R
+        P[[J]][, n - 1] <-deflation.result.J$p
+        cumsum_pjs=cumsum(pjs)[1:(J-1)]
+        inf_pjs=c(0,cumsum_pjs[1:(J-2)])+1          
+        for(j in 1:(J-1))
+        {
+          R[[j]]=R[[J]][,c(inf_pjs[j]:cumsum_pjs[j]),drop=FALSE]
+          rownames(R[[j]])=rownames(R[[j]])
+          colnames(R[[j]])=colnames(R[[J]])[c(inf_pjs[j]:cumsum_pjs[j])]
+          P[[j]][, n - 1] <- P[[J]][c(inf_pjs[j]:cumsum_pjs[j]), n - 1]
+        }
+   
+      }
+
+     
       if (is.vector(tau))
         rgcca.result <- rgccak(R, connection, tau = tau, scheme = scheme,
                                init = init, bias = bias, tol = tol,
@@ -277,7 +290,7 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
       for (b in 1:J) a[[b]][, n] <- rgcca.result$a[[b]]
       
       
-      for (b in 1:J_defl) astar[[b]][, n] <- rgcca.result$a[[b]] -
+      for (b in 1:J) astar[[b]][, n] <- rgcca.result$a[[b]] -
         astar[[b]][, (1:(n - 1)),drop = F] %*%
         drop( t(a[[b]][, n]) %*% P[[b]][, 1:(n - 1), drop = F] )
       

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -207,7 +207,7 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
   AVE_outer <- rep(NA, max(ncomp))
 
   Y <- NULL
-  P <- a <- astar <- NULL
+  P <- a <- astar <- list()
   crit <- list()
   AVE_inner <- rep(NA,max(ncomp))
 

--- a/R/rgccad.R
+++ b/R/rgccad.R
@@ -177,7 +177,7 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
                   tau = rep(1, length(blocks)),
                   ncomp = rep(1, length(blocks)), scheme = "centroid",
                   init = "svd", bias = TRUE, tol = 1e-08, verbose = TRUE,
-                  na.rm = TRUE, quiet = FALSE,superblock=FALSE)
+                  na.rm = TRUE, quiet = FALSE, superblock = FALSE)
 {
 
   if (mode(scheme) != "function") {
@@ -203,16 +203,24 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
   J <- length(blocks)
   pjs <- sapply(blocks,NCOL)
   nb_ind <- NROW(blocks[[1]])
-  AVE_X = list()
-  AVE_outer <- rep(NA,max(ncomp))
+  AVE_X <- list()
+  AVE_outer <- rep(NA, max(ncomp))
 
   Y <- NULL
   P <- a <- astar <- NULL
   crit <- list()
   AVE_inner <- rep(NA,max(ncomp))
 
-  for (b in 1:J) a[[b]] <- astar[[b]] <- matrix(NA, pjs[[b]], N + 1)
-  for (b in 1:J) Y[[b]] <- matrix(NA, nb_ind, N + 1)
+  for (b in seq_len(J)){
+    a[[b]] <- matrix(NA, pjs[[b]], N + 1)
+    Y[[b]] <- matrix(NA, nb_ind, N + 1)
+  }
+
+  if(!superblock){
+    for (b in seq_len(J)) astar[[b]] <- matrix(NA, pjs[b], N + 1)
+  }else{
+    astar <- matrix(NA, pjs[J], N + 1)
+  }
 
   # Whether primal or dual
   primal_dual = rep("primal", J)
@@ -233,46 +241,49 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
                            verbose = verbose, na.rm = na.rm)
   computed_tau[1, ] = rgcca.result$tau
 
-  for (b in 1:J) Y[[b]][, 1] <- rgcca.result$Y[, b, drop = FALSE]
-  for (b in 1:J) a[[b]][, 1] <- rgcca.result$a[[b]]
-  astar                      <- a
-  AVE_inner[1]               <- rgcca.result$AVE_inner
-  crit[[1]]                  <- rgcca.result$crit
+  for (b in seq_len(J)) Y[[b]][, 1] <- rgcca.result$Y[, b, drop = FALSE]
+  for (b in seq_len(J)) a[[b]][, 1] <- rgcca.result$a[[b]]
+
+  ifelse(!superblock,
+         astar <- a,
+         astar[, 1] <- a[[J]][, 1, drop = FALSE])
+
+  AVE_inner[1] <- rgcca.result$AVE_inner
+  crit[[1]] <- rgcca.result$crit
 
   if (N > 0) {
     R <- blocks
-    for (b in 1:J) P[[b]] <- matrix(NA, pjs[[b]], N)
+
+    if(!superblock){
+      for (b in seq_len(J)) P[[b]] <- matrix(NA, pjs[b], N)
+    }else{
+      P <- matrix(NA, pjs[J], N)
+    }
+
     for (n in 2:(N + 1)) {
       if (verbose)
         cat(paste0("Computation of the RGCCA block components #", n, " is under
                  progress...\n"))
 
-      if(!superblock)
-      {
-        defla.result <- defl.select(rgcca.result$Y, R, ndefl, n - 1, J, na.rm = na.rm)
-        R <- defla.result$resdefl
-        for (b in 1:J) P[[b]][, n - 1] <- defla.result$pdefl[[b]]
-      }
-  
-
-      if(superblock)
-      {
-        deflation.result.J=deflation(R[[J]], rgcca.result$Y[,J])
-        R[[J]]=deflation.result.J$R
-        P[[J]][, n - 1] <-deflation.result.J$p
-        cumsum_pjs=cumsum(pjs)[1:(J-1)]
-        inf_pjs=c(0,cumsum_pjs[1:(J-2)])+1          
-        for(j in 1:(J-1))
-        {
-          R[[j]]=R[[J]][,c(inf_pjs[j]:cumsum_pjs[j]),drop=FALSE]
-          rownames(R[[j]])=rownames(R[[j]])
-          colnames(R[[j]])=colnames(R[[J]])[c(inf_pjs[j]:cumsum_pjs[j])]
-          P[[j]][, n - 1] <- P[[J]][c(inf_pjs[j]:cumsum_pjs[j]), n - 1]
+      if(!superblock){
+        defl.result <- defl.select(rgcca.result$Y, R,
+                                   ndefl, n - 1, J,
+                                   na.rm = na.rm)
+        R <- defl.result$resdefl
+        for (b in seq_len(J)) P[[b]][, n - 1] <- defl.result$pdefl[[b]]
+      }else{
+        defl.result <- deflation(R[[J]], rgcca.result$Y[, J])
+        R[[J]] <- defl.result$R
+        P[, n - 1] <- defl.result$p
+        cumsum_pjs <- cumsum(pjs)[seq_len(J-1)]
+        inf_pjs <- c(0, cumsum_pjs[seq_len(J-2)])+1
+        for(j in seq_len(J-1)){
+          R[[j]] = R[[J]][ , inf_pjs[j]:cumsum_pjs[j], drop=FALSE]
+          rownames(R[[j]]) <- rownames(R[[j]])
+          colnames(R[[j]]) <- colnames(R[[J]])[inf_pjs[j]:cumsum_pjs[j]]
         }
-   
       }
 
-     
       if (is.vector(tau))
         rgcca.result <- rgccak(R, connection, tau = tau, scheme = scheme,
                                init = init, bias = bias, tol = tol,
@@ -281,43 +292,48 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
         rgcca.result <- rgccak(R, connection, tau = tau[n, ], scheme = scheme,
                                init = init, bias = bias, tol = tol,
                                verbose = verbose, na.rm = na.rm)
-      computed_tau[n, ] = rgcca.result$tau
+
+      computed_tau[n, ] <- rgcca.result$tau
 
       AVE_inner[n] <- rgcca.result$AVE_inner
       crit[[n]] <- rgcca.result$crit
 
-      for (b in 1:J) Y[[b]][, n] <- rgcca.result$Y[, b]
-      for (b in 1:J) a[[b]][, n] <- rgcca.result$a[[b]]
-      
-      if(!superblock)
-      {
-        for (b in 1:J) astar[[b]][, n] <- rgcca.result$a[[b]] -
-        astar[[b]][, (1:(n - 1)),drop = F] %*%
-        drop( t(a[[b]][, n]) %*% P[[b]][, 1:(n - 1), drop = F] )
+      for (b in seq_len(J)) Y[[b]][, n] <- rgcca.result$Y[, b]
+      for (b in seq_len(J)) a[[b]][, n] <- rgcca.result$a[[b]]
+
+      if(!superblock){
+        for (b in seq_len(J))
+          astar[[b]][, n] <- rgcca.result$a[[b]] -
+            astar[[b]][, (1:(n - 1)), drop = F] %*%
+        drop( t(a[[b]][, n]) %*% P[[b]][, 1:(n - 1), drop = F])
+      }else{
+        astar[, n] <- rgcca.result$a[[J]] -
+          astar[, (1:(n - 1)), drop = F] %*%
+            drop(t(a[[J]][, n]) %*% P[, 1:(n - 1), drop = F])
       }
-      if(superblock)
-      {
-        for (b in 1:(J-1)){ astar[[b]][, n] <- matrix(NA,nrow(rgcca.result$a[[b]]),ncol(rgcca.result$a[[b]]))}
-        astar[[J]][, n] <- rgcca.result$a[[J]] -
-            astar[[J]][, (1:(n - 1)),drop = F] %*%
-            drop( t(a[[J]][, n]) %*% P[[J]][, 1:(n - 1), drop = F] )
-      }
-    
     }
   }
 
-  for (b in 1:J) {
-    rownames(a[[b]]) = rownames(astar[[b]]) = colnames(blocks[[b]])
+  for (b in seq_len(J)) {
+    rownames(a[[b]]) = colnames(blocks[[b]])
     rownames(Y[[b]]) = rownames(blocks[[b]])
-    colnames(Y[[b]]) = paste0("comp", 1:max(ncomp))
+    colnames(Y[[b]]) = paste0("comp", seq_len(max(ncomp)))
   }
 
-  for (j in 1:J) AVE_X[[j]] = apply(
+  if(!superblock){
+    for (b in seq_len(J)) rownames(astar[[b]]) = colnames(blocks[[b]])
+    astar <- shave(astar, ncomp)
+   }else{
+    rownames(astar) <- colnames(blocks[[J]])
+    astar <- astar
+  }
+
+  for (j in seq_len(J)) AVE_X[[j]] = apply(
     cor(blocks[[j]], Y[[j]], use = "pairwise.complete.obs")^2, 2, mean)
 
   outer = matrix(unlist(AVE_X), nrow = max(ncomp))
 
-  for (j in 1:max(ncomp))
+  for (j in seq_len(max(ncomp)))
     AVE_outer[j] <- sum(pjs * outer[j,])/sum(pjs)
 
   Y = shave(Y, ncomp)
@@ -330,8 +346,9 @@ rgccad = function(blocks, connection = 1 - diag(length(blocks)),
     computed_tau = as.vector(computed_tau)
   }
 
-  out <- list(Y = shave(Y, ncomp), a = shave(a,ncomp),
-              astar = shave(astar, ncomp),
+  out <- list(Y = shave(Y, ncomp),
+              a = shave(a, ncomp),
+              astar = astar,
               tau = computed_tau,
               crit = crit, primal_dual = primal_dual,
               AVE = AVE)

--- a/R/scaling.R
+++ b/R/scaling.R
@@ -13,8 +13,8 @@ scaling <- function(blocks, scale = TRUE, bias = TRUE,
         if (scale_block == "lambda1") {
             blocks <- lapply(blocks, function(x) {
                 lambda = sqrt(ifelse(ncol(x) < nrow(x),
-                                eigen(crossprod(x))$values[1],
-                                eigen(tcrossprod(x))$values[1]))
+                                eigen(crossprod(x / sqrt_N))$values[1],
+                                eigen(tcrossprod(x / sqrt_N))$values[1]))
                 y = x / lambda
                 attr(y, "scaled:scale") = attr(x, "scaled:scale") * lambda
                 return(y)
@@ -33,8 +33,8 @@ scaling <- function(blocks, scale = TRUE, bias = TRUE,
         if (scale_block == "lambda1") {
             blocks <- lapply(blocks, function(x) {
                 lambda = sqrt(ifelse(ncol(x) < nrow(x),
-                                eigen(crossprod(x))$values[1],
-                                eigen(tcrossprod(x))$values[1])) / sqrt_N
+                                eigen(crossprod(x / sqrt_N))$values[1],
+                                eigen(tcrossprod(x / sqrt_N))$values[1]))
                 y = x / lambda
                 attr(y, "scaled:scale") = attr(x, "scaled:scale") * lambda
                 return(y)

--- a/R/scaling.R
+++ b/R/scaling.R
@@ -1,28 +1,45 @@
-scaling <- function(blocks, scale = TRUE, bias = TRUE, scale_block = TRUE) {
-    if(scale){
+scaling <- function(blocks, scale = TRUE, bias = TRUE,
+                    scale_block = "inertia") {
+    if (is.logical(scale_block) && scale_block) scale_block = "inertia"
+    sqrt_N = sqrt(NROW(blocks[[1]]) + bias - 1)
+
+    if (scale) {
         # Standardization of the variables of each block
         blocks <- lapply(blocks,
                          function(x) scale2(x, scale = TRUE, bias = bias)
-                         )
+        )
 
-        # Each block is divided by the square root of its number of variables
-        if(scale_block){
-           blocks <- lapply(blocks,
-                            function(x) {y <- x / sqrt(NCOL(x))
-                             attr(y, "scaled:scale") <-
-                                 attr(x, "scaled:scale")* sqrt(NCOL(x))
-            return(y)
+        # Each block is divided by a constant that depends on the block
+        if (scale_block == "lambda1") {
+            blocks <- lapply(blocks, function(x) {
+                lambda = sqrt(ifelse(ncol(x) < nrow(x),
+                                eigen(crossprod(x))$values[1],
+                                eigen(tcrossprod(x))$values[1]))
+                y = x / lambda
+                attr(y, "scaled:scale") = attr(x, "scaled:scale") * lambda
+                return(y)
             })
-
+        } else if (scale_block == "inertia") {
+            blocks <- lapply(blocks, function(x) {
+                y <- x / sqrt(NCOL(x))
+                attr(y, "scaled:scale") <- attr(x, "scaled:scale") * sqrt(NCOL(x))
+                return(y)
+            })
         }
-    } else{
-        blocks <- lapply(blocks,
-                         function(x)
-                             scale2(x, scale = FALSE, bias = bias)
-                         )
-
-        if (scale_block) {
-            sqrt_N = sqrt(NROW(blocks[[1]]) + bias - 1)
+    } else {
+        blocks <- lapply(blocks, function(x)
+            scale2(x, scale = FALSE, bias = bias)
+        )
+        if (scale_block == "lambda1") {
+            blocks <- lapply(blocks, function(x) {
+                lambda = sqrt(ifelse(ncol(x) < nrow(x),
+                                eigen(crossprod(x))$values[1],
+                                eigen(tcrossprod(x))$values[1])) / sqrt_N
+                y = x / lambda
+                attr(y, "scaled:scale") = attr(x, "scaled:scale") * lambda
+                return(y)
+            })
+        } else if (scale_block == "inertia") {
             blocks <- lapply(blocks, function(x) {
                 fac <- 1/sqrt_N * norm(x, type = "F")
                 out <- x / fac
@@ -30,7 +47,6 @@ scaling <- function(blocks, scale = TRUE, bias = TRUE, scale_block = TRUE) {
                 return(out)
             })
         }
-
     }
     return(blocks)
 }

--- a/R/sgcca.R
+++ b/R/sgcca.R
@@ -274,10 +274,6 @@ sgcca <- function(blocks, connection = 1 - diag(length(blocks)),
   }
 
   for (b in seq_len(J)) {
-    rownames(a[[b]]) = rownames(astar[[b]]) = colnames(blocks[[b]])
-    rownames(Y[[b]]) = rownames(blocks[[b]])
-    colnames(Y[[b]]) = paste0("comp", 1:max(ncomp))
-
     #Average Variance Explained (AVE) per block
     AVE_X[[b]] =  apply(cor(blocks[[b]], Y[[b]], use = "pairwise.complete.obs")^2, 2,
                       mean, na.rm = TRUE)
@@ -287,16 +283,15 @@ sgcca <- function(blocks, connection = 1 - diag(length(blocks)),
   outer = matrix(unlist(AVE_X), nrow = max(ncomp))
   AVE_outer <- as.numeric((outer %*% pjs)/sum(pjs))
 
-  Y = shave(Y, ncomp)
   AVE_X = shave(AVE_X, ncomp)
 
   AVE <- list(AVE_X = AVE_X, AVE_outer = AVE_outer, AVE_inner = AVE_inner)
 
   if (N == 0) crit = unlist(crit)
 
-  out <- list(Y = shave(Y, ncomp),
-              a = shave(a, ncomp),
-              astar = shave(astar, ncomp),
+  out <- list(Y = Y,
+              a = a,
+              astar = astar,
               crit = crit,
               AVE = AVE)
 

--- a/R/sgcca.R
+++ b/R/sgcca.R
@@ -51,7 +51,7 @@
 #' @title Variable Selection For Generalized Canonical Correlation Analysis
 #' (SGCCA)
 #' @examples
-#'
+#' @param superblock TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)
 #' #############
 #' # Example 1 #
 #' #############
@@ -137,7 +137,7 @@ sgcca <- function(blocks, connection = 1 - diag(length(blocks)),
                   sparsity = rep(1, length(blocks)),
                   ncomp = rep(1, length(blocks)), scheme = "centroid",
                   init = "svd", bias = TRUE, tol = .Machine$double.eps,
-                  verbose = FALSE,   quiet = FALSE, na.rm = TRUE){
+                  verbose = FALSE,   quiet = FALSE, na.rm = TRUE,superblock=FALSE){
 
   # ndefl number of deflation per block
   ndefl <- ncomp - 1

--- a/R/sgcca.R
+++ b/R/sgcca.R
@@ -51,7 +51,6 @@
 #' @title Variable Selection For Generalized Canonical Correlation Analysis
 #' (SGCCA)
 #' @examples
-#' @param superblock TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)
 #' #############
 #' # Example 1 #
 #' #############

--- a/man/rgcca.Rd
+++ b/man/rgcca.Rd
@@ -91,8 +91,7 @@ or by random initialisation ("random") (default: "svd").}
 the response argument is filled the supervised mode is automatically
 activated.}
 
-\item{superblock}{Boolean indicating the presence of the superblock.
-Default = TRUE}
+\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)}
 
 \item{NA_method}{Character string corresponding to the method used for
 handling missing values ("nipals", "complete"). (default: "nipals").

--- a/man/rgcca.Rd
+++ b/man/rgcca.Rd
@@ -8,7 +8,7 @@ rgcca(
   blocks,
   method = "rgcca",
   scale = TRUE,
-  scale_block = TRUE,
+  scale_block = "inertia",
   connection = 1 - diag(length(blocks)),
   scheme = "factorial",
   ncomp = rep(1, length(blocks)),
@@ -38,8 +38,13 @@ sumcov-1, sumcov-2, sumcov, sabscov, sabscov-1, sabscov-2.}
 
 \item{scale}{Logical value indicating if blocks are standardized.}
 
-\item{scale_block}{Logical value indicating if each block is divided by
-the square root of its number of variables.}
+\item{scale_block}{Value indicating if each block is divided by
+a constant value. If TRUE or "inertia", each block is divided by the
+Frobenius norm of its empirical covariance matrix. If "lambda1", each block
+is divided by the square root of the highest eigenvalue of its empirical
+covariance matrix. Otherwise the blocks are not scaled. If standardization is
+applied (scale = TRUE), the block scaling is applied on the result of the
+standardization.}
 
 \item{connection}{A symmetric matrix (J*J) that describes the relationships between
 blocks.}
@@ -91,7 +96,8 @@ or by random initialisation ("random") (default: "svd").}
 the response argument is filled the supervised mode is automatically
 activated.}
 
-\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)}
+\item{superblock}{TRUE if a superblock is added, FALSE otherwise (deflation
+strategy must be adapted when a superblock is used).}
 
 \item{NA_method}{Character string corresponding to the method used for
 handling missing values ("nipals", "complete"). (default: "nipals").

--- a/man/rgcca.Rd
+++ b/man/rgcca.Rd
@@ -40,9 +40,10 @@ sumcov-1, sumcov-2, sumcov, sabscov, sabscov-1, sabscov-2.}
 
 \item{scale_block}{Value indicating if each block is divided by
 a constant value. If TRUE or "inertia", each block is divided by the
-Frobenius norm of its empirical covariance matrix. If "lambda1", each block
-is divided by the square root of the highest eigenvalue of its empirical
-covariance matrix. Otherwise the blocks are not scaled. If standardization is
+sum of eigenvalues of its empirical covariance matrix.
+If "lambda1", each block is divided by the square root of the highest
+eigenvalue of its empirical covariance matrix.
+Otherwise the blocks are not scaled. If standardization is
 applied (scale = TRUE), the block scaling is applied on the result of the
 standardization.}
 

--- a/man/rgcca_cv.Rd
+++ b/man/rgcca_cv.Rd
@@ -78,8 +78,7 @@ one row by combination. By default, it takes 10 sets between min values (0
 
 \item{quiet}{Logical value indicating if warning messages are reported.}
 
-\item{superblock}{Boolean indicating the presence of the superblock.
-Default = TRUE}
+\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)}
 
 \item{scale}{Logical value indicating if blocks are standardized.}
 

--- a/man/rgcca_cv.Rd
+++ b/man/rgcca_cv.Rd
@@ -85,9 +85,10 @@ strategy must be adapted when a superblock is used).}
 
 \item{scale_block}{Value indicating if each block is divided by
 a constant value. If TRUE or "inertia", each block is divided by the
-Frobenius norm of its empirical covariance matrix. If "lambda1", each block
-is divided by the square root of the highest eigenvalue of its empirical
-covariance matrix. Otherwise the blocks are not scaled. If standardization is
+sum of eigenvalues of its empirical covariance matrix.
+If "lambda1", each block is divided by the square root of the highest
+eigenvalue of its empirical covariance matrix.
+Otherwise the blocks are not scaled. If standardization is
 applied (scale = TRUE), the block scaling is applied on the result of the
 standardization.}
 

--- a/man/rgcca_cv.Rd
+++ b/man/rgcca_cv.Rd
@@ -78,12 +78,18 @@ one row by combination. By default, it takes 10 sets between min values (0
 
 \item{quiet}{Logical value indicating if warning messages are reported.}
 
-\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)}
+\item{superblock}{TRUE if a superblock is added, FALSE otherwise (deflation
+strategy must be adapted when a superblock is used).}
 
 \item{scale}{Logical value indicating if blocks are standardized.}
 
-\item{scale_block}{Logical value indicating if each block is divided by
-the square root of its number of variables.}
+\item{scale_block}{Value indicating if each block is divided by
+a constant value. If TRUE or "inertia", each block is divided by the
+Frobenius norm of its empirical covariance matrix. If "lambda1", each block
+is divided by the square root of the highest eigenvalue of its empirical
+covariance matrix. Otherwise the blocks are not scaled. If standardization is
+applied (scale = TRUE), the block scaling is applied on the result of the
+standardization.}
 
 \item{tol}{The stopping value for the convergence of the algorithm.}
 

--- a/man/rgcca_cv_k.Rd
+++ b/man/rgcca_cv_k.Rd
@@ -44,8 +44,13 @@ scaled.}
 
 \item{scale}{Logical value indicating if blocks are standardized.}
 
-\item{scale_block}{Logical value indicating if each block is divided by
-the square root of its number of variables.}
+\item{scale_block}{Value indicating if each block is divided by
+a constant value. If TRUE or "inertia", each block is divided by the
+Frobenius norm of its empirical covariance matrix. If "lambda1", each block
+is divided by the square root of the highest eigenvalue of its empirical
+covariance matrix. Otherwise the blocks are not scaled. If standardization is
+applied (scale = TRUE), the block scaling is applied on the result of the
+standardization.}
 
 \item{tol}{The stopping value for the convergence of the algorithm.}
 

--- a/man/rgcca_cv_k.Rd
+++ b/man/rgcca_cv_k.Rd
@@ -46,9 +46,10 @@ scaled.}
 
 \item{scale_block}{Value indicating if each block is divided by
 a constant value. If TRUE or "inertia", each block is divided by the
-Frobenius norm of its empirical covariance matrix. If "lambda1", each block
-is divided by the square root of the highest eigenvalue of its empirical
-covariance matrix. Otherwise the blocks are not scaled. If standardization is
+sum of eigenvalues of its empirical covariance matrix.
+If "lambda1", each block is divided by the square root of the highest
+eigenvalue of its empirical covariance matrix.
+Otherwise the blocks are not scaled. If standardization is
 applied (scale = TRUE), the block scaling is applied on the result of the
 standardization.}
 

--- a/man/rgcca_permutation.Rd
+++ b/man/rgcca_permutation.Rd
@@ -63,9 +63,10 @@ is 20).}
 
 \item{scale_block}{Value indicating if each block is divided by
 a constant value. If TRUE or "inertia", each block is divided by the
-Frobenius norm of its empirical covariance matrix. If "lambda1", each block
-is divided by the square root of the highest eigenvalue of its empirical
-covariance matrix. Otherwise the blocks are not scaled. If standardization is
+sum of eigenvalues of its empirical covariance matrix.
+If "lambda1", each block is divided by the square root of the highest
+eigenvalue of its empirical covariance matrix.
+Otherwise the blocks are not scaled. If standardization is
 applied (scale = TRUE), the block scaling is applied on the result of the
 standardization.}
 

--- a/man/rgcca_permutation.Rd
+++ b/man/rgcca_permutation.Rd
@@ -61,8 +61,13 @@ is 20).}
 
 \item{scale}{Logical value indicating if blocks are standardized.}
 
-\item{scale_block}{Logical value indicating if each block is divided by
-the square root of its number of variables.}
+\item{scale_block}{Value indicating if each block is divided by
+a constant value. If TRUE or "inertia", each block is divided by the
+Frobenius norm of its empirical covariance matrix. If "lambda1", each block
+is divided by the square root of the highest eigenvalue of its empirical
+covariance matrix. Otherwise the blocks are not scaled. If standardization is
+applied (scale = TRUE), the block scaling is applied on the result of the
+standardization.}
 
 \item{method}{A character string indicating the multi-block component
 method to consider: rgcca, sgcca, pca, spca, pls, spls, cca,

--- a/man/rgccad.Rd
+++ b/man/rgccad.Rd
@@ -64,7 +64,8 @@ algorithm is reported while computing.}
 
 \item{quiet}{Logical value indicating if warning messages are reported.}
 
-\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)}
+\item{superblock}{TRUE if a superblock is added, FALSE otherwise (deflation
+strategy must be adapted when a superblock is used).}
 }
 \value{
 \item{Y}{A list of \eqn{J} elements. Each element of the list is a

--- a/man/rgccad.Rd
+++ b/man/rgccad.Rd
@@ -15,7 +15,8 @@ rgccad(
   tol = 1e-08,
   verbose = TRUE,
   na.rm = TRUE,
-  quiet = FALSE
+  quiet = FALSE,
+  superblock = FALSE
 )
 }
 \arguments{
@@ -62,6 +63,8 @@ algorithm is reported while computing.}
 \item{na.rm}{If TRUE, runs rgcca only on available data.}
 
 \item{quiet}{Logical value indicating if warning messages are reported.}
+
+\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)}
 }
 \value{
 \item{Y}{A list of \eqn{J} elements. Each element of the list is a

--- a/man/sgcca.Rd
+++ b/man/sgcca.Rd
@@ -16,7 +16,8 @@ sgcca(
   tol = .Machine$double.eps,
   verbose = FALSE,
   quiet = FALSE,
-  na.rm = TRUE
+  na.rm = TRUE,
+  superblock = FALSE
 )
 }
 \arguments{
@@ -64,50 +65,8 @@ or by random initialisation ("random") (default: "svd").}
 \item{quiet}{Logical value indicating if warning messages are reported.}
 
 \item{na.rm}{If TRUE, runs rgcca only on available data.}
-}
-\value{
-\item{Y}{A list of \eqn{J} elements. Each element of \eqn{Y} is a
-matrix that contains the analysis components for the corresponding block.}
 
-\item{a}{A list of \eqn{J} elements. Each element of \eqn{a} is a
-matrix that contains the outer weight vectors for each block.}
-
-\item{astar}{A list of \eqn{J} elements. Each element of astar is a
-matrix defined as Y[[j]][, h] = blocks[[j]]\%*\%astar[[j]][, h]}
-
-\item{crit}{A vector of integer that contains for each component the
-values of the analysis criteria across iterations.}
-
-\item{AVE}{A list of numerical values giving the indicators of model
-quality based on the Average Variance Explained (AVE): AVE(for each block),
-AVE(outer model), AVE(inner model).}
-}
-\description{
-SGCCA extends RGCCA to address the issue of variable selection. Specifically,
-RGCCA is combined with an L1-penalty that gives rise to Sparse GCCA (SGCCA)
-which is implemented in the function sgcca().
-Given \eqn{J} matrices \eqn{X_1, X_2, ..., X_J}, that represent
-\eqn{J} sets of variables observed on the same set of \eqn{n} individuals.
-The matrices \eqn{X_1, X_2, ..., X_J} must have the same number of rows, but
-may (and usually will) have different numbers of columns. Blocks are not
-necessarily fully connected within the SGCCA framework. Hence the use of
-SGCCA requires the construction (user specified) of a design matrix (\eqn{connection})
-that characterizes the connections between blocks. Elements of the symmetric
-design matrix \eqn{connection = (c_{jk})} are equal to 1 if block \eqn{j} and block
-\eqn{k} are connected, and 0 otherwise. The SGCCA algorithm is very similar
-to the RGCCA algorithm and keeps the same monotone convergence properties
-(i.e. the bounded criteria to be maximized increases at each step of the
-iterative procedure and hits at convergence a stationary point).
-Moreover, using a deflation strategy, sgcca() enables the computation of
-several SGCCA block components (specified by ncomp) for each block. Block
-components for each block are guaranteed to be orthogonal when using this
-deflation strategy. The so-called symmetric deflation is considered in this
-implementation, i.e. each block is deflated with respect to its own
-component. Moreover, we stress that the numbers of components per block
-could differ from one block to another.
-}
-\examples{
-
+\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)
 #############
 # Example 1 #
 #############
@@ -186,7 +145,48 @@ result.sgcca = sgcca(blocks, connection, sparsity = matrix(c(.071,.2, 1, 0.06, 0
                      ncomp = c(2, 2, 1), scheme = "factorial",
                      bias = TRUE,
                      init = init, verbose = TRUE)
+}}
 }
+\value{
+\item{Y}{A list of \eqn{J} elements. Each element of \eqn{Y} is a
+matrix that contains the analysis components for the corresponding block.}
+
+\item{a}{A list of \eqn{J} elements. Each element of \eqn{a} is a
+matrix that contains the outer weight vectors for each block.}
+
+\item{astar}{A list of \eqn{J} elements. Each element of astar is a
+matrix defined as Y[[j]][, h] = blocks[[j]]\%*\%astar[[j]][, h]}
+
+\item{crit}{A vector of integer that contains for each component the
+values of the analysis criteria across iterations.}
+
+\item{AVE}{A list of numerical values giving the indicators of model
+quality based on the Average Variance Explained (AVE): AVE(for each block),
+AVE(outer model), AVE(inner model).}
+}
+\description{
+SGCCA extends RGCCA to address the issue of variable selection. Specifically,
+RGCCA is combined with an L1-penalty that gives rise to Sparse GCCA (SGCCA)
+which is implemented in the function sgcca().
+Given \eqn{J} matrices \eqn{X_1, X_2, ..., X_J}, that represent
+\eqn{J} sets of variables observed on the same set of \eqn{n} individuals.
+The matrices \eqn{X_1, X_2, ..., X_J} must have the same number of rows, but
+may (and usually will) have different numbers of columns. Blocks are not
+necessarily fully connected within the SGCCA framework. Hence the use of
+SGCCA requires the construction (user specified) of a design matrix (\eqn{connection})
+that characterizes the connections between blocks. Elements of the symmetric
+design matrix \eqn{connection = (c_{jk})} are equal to 1 if block \eqn{j} and block
+\eqn{k} are connected, and 0 otherwise. The SGCCA algorithm is very similar
+to the RGCCA algorithm and keeps the same monotone convergence properties
+(i.e. the bounded criteria to be maximized increases at each step of the
+iterative procedure and hits at convergence a stationary point).
+Moreover, using a deflation strategy, sgcca() enables the computation of
+several SGCCA block components (specified by ncomp) for each block. Block
+components for each block are guaranteed to be orthogonal when using this
+deflation strategy. The so-called symmetric deflation is considered in this
+implementation, i.e. each block is deflated with respect to its own
+component. Moreover, we stress that the numbers of components per block
+could differ from one block to another.
 }
 \references{
 Tenenhaus, A., Philippe, C., Guillemot, V., Le Cao, K. A.,

--- a/man/sgcca.Rd
+++ b/man/sgcca.Rd
@@ -66,7 +66,51 @@ or by random initialisation ("random") (default: "svd").}
 
 \item{na.rm}{If TRUE, runs rgcca only on available data.}
 
-\item{superblock}{TRUE if a superblock is added, FALSE ifelse (useful for deflation strategy when a superblock is used)
+\item{superblock}{Boolean indicating the presence of the superblock.
+Default = TRUE}
+}
+\value{
+\item{Y}{A list of \eqn{J} elements. Each element of \eqn{Y} is a
+matrix that contains the analysis components for the corresponding block.}
+
+\item{a}{A list of \eqn{J} elements. Each element of \eqn{a} is a
+matrix that contains the outer weight vectors for each block.}
+
+\item{astar}{A list of \eqn{J} elements. Each element of astar is a
+matrix defined as Y[[j]][, h] = blocks[[j]]\%*\%astar[[j]][, h]}
+
+\item{crit}{A vector of integer that contains for each component the
+values of the analysis criteria across iterations.}
+
+\item{AVE}{A list of numerical values giving the indicators of model
+quality based on the Average Variance Explained (AVE): AVE(for each block),
+AVE(outer model), AVE(inner model).}
+}
+\description{
+SGCCA extends RGCCA to address the issue of variable selection. Specifically,
+RGCCA is combined with an L1-penalty that gives rise to Sparse GCCA (SGCCA)
+which is implemented in the function sgcca().
+Given \eqn{J} matrices \eqn{X_1, X_2, ..., X_J}, that represent
+\eqn{J} sets of variables observed on the same set of \eqn{n} individuals.
+The matrices \eqn{X_1, X_2, ..., X_J} must have the same number of rows, but
+may (and usually will) have different numbers of columns. Blocks are not
+necessarily fully connected within the SGCCA framework. Hence the use of
+SGCCA requires the construction (user specified) of a design matrix (\eqn{connection})
+that characterizes the connections between blocks. Elements of the symmetric
+design matrix \eqn{connection = (c_{jk})} are equal to 1 if block \eqn{j} and block
+\eqn{k} are connected, and 0 otherwise. The SGCCA algorithm is very similar
+to the RGCCA algorithm and keeps the same monotone convergence properties
+(i.e. the bounded criteria to be maximized increases at each step of the
+iterative procedure and hits at convergence a stationary point).
+Moreover, using a deflation strategy, sgcca() enables the computation of
+several SGCCA block components (specified by ncomp) for each block. Block
+components for each block are guaranteed to be orthogonal when using this
+deflation strategy. The so-called symmetric deflation is considered in this
+implementation, i.e. each block is deflated with respect to its own
+component. Moreover, we stress that the numbers of components per block
+could differ from one block to another.
+}
+\examples{
 #############
 # Example 1 #
 #############
@@ -145,48 +189,7 @@ result.sgcca = sgcca(blocks, connection, sparsity = matrix(c(.071,.2, 1, 0.06, 0
                      ncomp = c(2, 2, 1), scheme = "factorial",
                      bias = TRUE,
                      init = init, verbose = TRUE)
-}}
 }
-\value{
-\item{Y}{A list of \eqn{J} elements. Each element of \eqn{Y} is a
-matrix that contains the analysis components for the corresponding block.}
-
-\item{a}{A list of \eqn{J} elements. Each element of \eqn{a} is a
-matrix that contains the outer weight vectors for each block.}
-
-\item{astar}{A list of \eqn{J} elements. Each element of astar is a
-matrix defined as Y[[j]][, h] = blocks[[j]]\%*\%astar[[j]][, h]}
-
-\item{crit}{A vector of integer that contains for each component the
-values of the analysis criteria across iterations.}
-
-\item{AVE}{A list of numerical values giving the indicators of model
-quality based on the Average Variance Explained (AVE): AVE(for each block),
-AVE(outer model), AVE(inner model).}
-}
-\description{
-SGCCA extends RGCCA to address the issue of variable selection. Specifically,
-RGCCA is combined with an L1-penalty that gives rise to Sparse GCCA (SGCCA)
-which is implemented in the function sgcca().
-Given \eqn{J} matrices \eqn{X_1, X_2, ..., X_J}, that represent
-\eqn{J} sets of variables observed on the same set of \eqn{n} individuals.
-The matrices \eqn{X_1, X_2, ..., X_J} must have the same number of rows, but
-may (and usually will) have different numbers of columns. Blocks are not
-necessarily fully connected within the SGCCA framework. Hence the use of
-SGCCA requires the construction (user specified) of a design matrix (\eqn{connection})
-that characterizes the connections between blocks. Elements of the symmetric
-design matrix \eqn{connection = (c_{jk})} are equal to 1 if block \eqn{j} and block
-\eqn{k} are connected, and 0 otherwise. The SGCCA algorithm is very similar
-to the RGCCA algorithm and keeps the same monotone convergence properties
-(i.e. the bounded criteria to be maximized increases at each step of the
-iterative procedure and hits at convergence a stationary point).
-Moreover, using a deflation strategy, sgcca() enables the computation of
-several SGCCA block components (specified by ncomp) for each block. Block
-components for each block are guaranteed to be orthogonal when using this
-deflation strategy. The so-called symmetric deflation is considered in this
-implementation, i.e. each block is deflated with respect to its own
-component. Moreover, we stress that the numbers of components per block
-could differ from one block to another.
 }
 \references{
 Tenenhaus, A., Philippe, C., Guillemot, V., Le Cao, K. A.,

--- a/tests/testthat/test_checks.r
+++ b/tests/testthat/test_checks.r
@@ -246,8 +246,8 @@ test_that("check_ncomp raises an error if blocks and ncomp have different
 test_that("check_ncomp raises an error if any element of ncomp is greater than
           the number of variables in the corresponding block", {
             expect_error(check_ncomp(c(2, 7, 2), blocks),
-                         paste0("ncomp[2] should be lower than 2 (that is ",
-                                "the number of variables of block 2)."),
+                         paste0("ncomp[2] should be lower than 2 (i.e. ",
+                                "the number of variables for block 2)."),
                          fixed = TRUE)
           })
 test_that("check_ncomp raises an error for invalid ncomp", {

--- a/tests/testthat/test_print_bootstrap.r
+++ b/tests/testthat/test_print_bootstrap.r
@@ -19,7 +19,7 @@ boot = bootstrap(res, n_cores = 1)
 print(boot)
 plot(boot)
 
-res = rgcca(A, ncomp = c(2, 1, 2), tau = c(1, 1, 1),
+res = rgcca(A, ncomp = c(2, 2, 2), tau = c(1, 1, 1),
             scheme = "factorial", scale = TRUE,
             verbose = FALSE, superblock = TRUE)
 boot = bootstrap(res, n_cores = 1)

--- a/tests/testthat/test_rgcca.R
+++ b/tests/testthat/test_rgcca.R
@@ -1,368 +1,179 @@
 library(cluster)
 library(FactoMineR)
 
-# setwd("/home/caroline.peltier/Bureau/RGCCA")
-# lapply(list.files("./R"),function(x){source(paste0("./R/",x))})
+tol = 1e-14
+
 data(Russett)
-X_agric =as.matrix(Russett[,c("gini","farm","rent")]);
-X_ind = as.matrix(Russett[,c("gnpr","labo")]);
-X_polit = as.matrix(Russett[ , c("demostab", "dictator")]);
-A = list(X_agric);
-
-
-#C = matrix(c(0, 0, 1, 0, 0, 1, 1, 1, 0), 3, 3);
-
-# scaled PCA
-resPCA= rgcca (
-     blocks=A,
-     connection = 1 - diag(length(A)),
-     response = NULL,
-     superblock = FALSE,
-     tau = rep(1, length(A)),
-     ncomp = rep(2, length(A)),
-     method = "pca",
-     verbose = FALSE,
-     scheme = "factorial",
-     scale = TRUE,
-     init = "svd",
-     bias = TRUE,
-     tol = 1e-08)
-
-names(resPCA)
-(resPCA$astar)
-resPCAprcomp=prcomp(A[[1]],scale=TRUE)
-
-varExplPrComp=as.vector((resPCAprcomp$sdev)^2/sum((resPCAprcomp$sdev)^2))[1]
-varExplRgcca=resPCA$AVE$AVE_X[[1]][1]
-pca_varexpl=round(varExplPrComp-varExplRgcca,digits=4)==0
-pca_ind=abs(cor(resPCAprcomp$x[,1],resPCA$Y[[1]][,1]))==1
-pca_ind2=abs(cor(resPCAprcomp$x[,2],resPCA$Y[[1]][,2]))==1
-pca_var=abs(cor(resPCAprcomp$rotation[,1],resPCA$astar[[1]][,1]))==1
-pca_var2=round(abs(cor(resPCAprcomp$rotation[,2],resPCA$astar[[1]][,2])), 12)==1
-
-test_that("pca_varexpl",{expect_true(pca_varexpl)})
-pca_eig=abs(varExplPrComp-varExplRgcca)<1e-8
-test_that("pca_ind",{expect_true(pca_ind)})
-test_that("pca_var",{expect_true(pca_var)})
-test_that("pca_eig",{expect_true(pca_eig)})
-test_that("pca_ind2",{expect_true(pca_ind2)})
-test_that("pca_var2",{expect_true(pca_var2)})
-
-
-
-# unscaled PCA
-unscaledPCA= rgcca (
-    blocks=A,
-    connection = 1 - diag(length(A)),
-    response = NULL,
-    superblock = FALSE,
-    tau = rep(1, length(A)),
-    ncomp = rep(2, length(A)),
-    method = "pca",
-    verbose = FALSE,
-    scheme = "factorial",
-    scale_block = FALSE,
-    scale = FALSE,
-    init = "svd",
-    bias = TRUE,
-    tol = 1e-08)
-unscaledPCAprcomp=prcomp(A[[1]],scale=FALSE)
-unscaledvarExplPrComp=as.vector((unscaledPCAprcomp$sdev)^2/sum((unscaledPCAprcomp$sdev)^2))[1]
-unscaledvarExplRgcca=unscaledPCA$AVE$AVE_X[[1]][1]
-upca_varexpl=round(unscaledvarExplPrComp-unscaledvarExplRgcca,digits=4)==0
-upca_ind=abs(abs(cor(unscaledPCAprcomp$x[,1],unscaledPCA$Y[[1]][,1])) - 1) < .Machine$double.eps
-upca_var=abs(cor(unscaledPCAprcomp$rotation[,1],unscaledPCA$astar[[1]][,1]))==1
-upca_ind2=abs(cor(unscaledPCAprcomp$x[,2],unscaledPCA$Y[[1]][,2]))==1
-upca_var2=round(abs(cor(unscaledPCAprcomp$rotation[,2],unscaledPCA$astar[[1]][,2])),digits=12)==1
-
-test_that("upca_ind",{expect_true(upca_ind)})
-test_that("upca_var",{expect_true(upca_var)})
-test_that("upca_ind2",{expect_true(upca_ind)})
-test_that("upca_var2",{expect_true(upca_var)})
-#test_that("upca_varexpl",{expect_true(upca_varexpl)})
-
-#testthat("upca_eig",{expect_true(abs(unscaledvarExplPrComp-unscaledvarExplRgcca<1e-8))}) #TODO
-
-
-
-#------------PLS
-#  res_pls = plsr(X_polit ~ X_agric, ncomp = 1, NA_method = "simpls")
-#  A = list(X_agric,X_polit);
-#  pls_with_rgcca= rgcca (
-#      blocks=A,
-#      connection=matrix(c(0,1,1,0),2,2),
-#      tau=rep(1,2),
-#      ncomp = rep(1, length(A)),
-#     scale_block=FALSE)
-#
-# #
-#  cor_X = abs(cor(res_pls$fitted.values[,,1][,1], pls_with_rgcca$Y[[1]]))
-#  cor_Y = abs(drop(cor(res_pls$Yloadings, pls_with_rgcca$a[[2]])))
-#  cor_X
-#  cor_Y
-#
-# cor_X
-# cor_Y
-# library(spls)
-# #Loadings are indeed the same (just difference of normalization)
-# plot(cor_X*pls_with_rgcca$a[[1]], col = "red", pch = 16, main = "X_loadings", ylab = "loadings")
-# points(res_pls$projection/norm2(res_pls$projection))
-#
-# plot(cor_X*res_rgcca$a[[2]], col = "red", pch = 16, main = "Y_loadings", ylab = "loadings")
-# points(res_pls$Yloadings/norm2(res_pls$Yloadings))
-
-# Test with block with 1 variable only
- data(Russett)
- X_agric =as.matrix(Russett[,c("gini","farm","rent")]);
- X_ind = as.matrix(Russett[,c("gnpr","labo")]);
- X_polit = as.matrix(Russett[ , c("demostab")]);
- A = list(X_agric,X_ind,X_polit);
- resPCA= rgcca ( blocks=A, ncomp = c(2,2,1),method = "rgcca",     verbose = FALSE)
-
- # with optimal tau
- data(Russett)
- X_agric =as.matrix(Russett[,c("gini","farm","rent")]);
- X_ind = as.matrix(Russett[,c("gnpr","labo")]);
- X_polit = as.matrix(Russett[ , c("demostab")]);
- A = list(X_agric,X_ind,X_agric);
- resRGCCA= rgcca( blocks=A,     connection = 1 - diag(length(A)),     response = NULL,     superblock = FALSE,     tau = rep("optimal", length(A)))
-
- # Testing quiet=TRUE/quiet=FALSE with tau optimal
- A = list(X_agric,X_ind,X_agric);
- names(A)=c("Agri","Ind","Polit")
- resRGCCA= rgcca ( blocks=A, tau = rep("optimal", length(A)),   quiet=FALSE)
-
-
- data(Russett)
- X_agric =as.matrix(Russett[,c("gini","farm","rent")]);
- X_ind = as.matrix(Russett[,c("gnpr","labo")]);
- X_polit = as.matrix(Russett[ , 6:11]);
- A = list(X_agric,X_ind,X_polit);
- names(A)=c("Agri","Ind","Polit")
-
- C0=matrix(0,3,3);C0[2:3,1]=1;C0[1,2:3]=1
- C1=matrix(0,3,3);C1[1:2,3]=1;C1[3,1:2]=1
- A1=list(A[[2]],A[[3]],A[[1]])
- resRgccaNipals3=rgcca(blocks=A1,connection=C1,method="rgcca",NA_method="nipals",ncomp=2)
- resRgccaNipals=rgcca(blocks=A,connection=C0,method="rgcca",NA_method="nipals",ncomp=2)
- head(resRgccaNipals3$Y[[3]])
- head(resRgccaNipals$Y[[1]])
-
-
- mat=matrix(rnorm(500),nrow=10,ncol=50);rownames(mat)=paste0("S",1:10);colnames(mat)=paste0("R",1:50)
- A=list(mat)
- resPCA= rgcca (
-     blocks=A,
-     connection = 1 - diag(length(A)),
-     response = NULL,
-     superblock = FALSE,
-     tau = rep(1, length(A)),
-     ncomp = rep(2, length(A)),
-     method = "pca",
-     verbose = FALSE,
-     scheme = "factorial",
-     scale = TRUE,
-     init = "svd",
-     bias = TRUE,
-     tol = 1e-08)
-
- names(resPCA)
- (resPCA$astar)
- resPCAprcomp=prcomp(A[[1]],scale=TRUE)
- pca_ind=abs(cor(resPCAprcomp$x[,1],resPCA$Y[[1]][,1]))==1
-
- # With a response and a qualitative variable to predict
- data(Russett)
- X_agric =as.matrix(Russett[,c("gini","farm","rent")]);
- X_ind = as.matrix(Russett[,c("gnpr","labo")]);
- X_polit = as.matrix(Russett[ , c("dictator")]);
- X_polit[X_polit==1]="dictator"
- X_polit[X_polit==0]="Non-dic"
- A_quali = list(agric=X_agric,X_ind=X_ind,X_polit=X_polit);
- res_rgcca_quali= rgcca (
-     blocks=A_quali, connection = 1 - diag(length(A)),
-     response = 3)
-
-#Checking the superbloc
- rgcca_with_superblock= rgcca (
-     blocks=A,
-     superblock = TRUE)
- head(lapply(A,function(x){y=scale2(x,scale=TRUE);return(y/sqrt(ncol(y)))})[[1]])
- head(rgcca_with_superblock$call$blocks[[1]])
- test_that("superblock",{expect_true( sum(head(rgcca_with_superblock$call$blocks[[length(A)+1]])[,1:ncol(A[[1]])]!=head(lapply(A,function(x){y=scale2(x,scale=TRUE);return(y/sqrt(ncol(y)))})[[1]]))==0
- )})
-
- # with permutation
- X_agric =as.matrix(Russett[,c("gini","farm","rent")]);
- X_ind = as.matrix(Russett[,c("gnpr","labo")]);
- X_polit = as.matrix(Russett[ , 6:11]);
- A = list(X_agric,X_ind,X_polit);
- names(A)=c("Agri","Ind","Polit")
- res_perm=rgcca_permutation(A,par_type="tau",n_cores=1,par_length=3)
- rgcca(res_perm)
- res_cv=rgcca_cv(A,response=1,n_cores=1,par_length=3)
- rgcca(res_cv)
-
- # SGCCA and RGCCA
- resRgcca = rgcca(blocks=A, ncomp=rep(2,3), scheme = "factorial", scale = TRUE,verbose=FALSE)
- resRgccad=rgccad(blocks=resRgcca$call$blocks,connection=matrix(1,3,3)-diag(1,3),ncomp=rep(2,3),scheme = "factorial", verbose=FALSE)
- test_that("rgccaVSrgccad",{expect_true(sum(head(resRgccad$Y[[1]])==head(resRgcca$Y[[1]]))==12)})
-
- resSgcca = rgcca(A, method="sgcca",ncomp=rep(2,3),sparsity= c(1, 1, 1), scheme = "factorial", scale = TRUE,verbose=FALSE,init="svd")
- resSgccad=sgcca(blocks=resSgcca$call$blocks,connection=matrix(1,3,3)-diag(1,3),ncomp=rep(2,3),scheme = "factorial",verbose=T,init="svd")
- test_that("sgccadVsSGCCA",{expect_true(mean((resSgccad$Y[[2]]-resSgcca$Y[[2]]))<1e-14)})
- test_that("sgcca",{expect_true( mean(abs(resSgcca$Y[[2]]-resRgcca$Y[[2]]))<1e-14)})
-
-
- resSgcca = rgcca(A, method="sgcca",superblock=TRUE)
-
-
-# Recovering MFA
-
-
-
- df = Russett[, c("gini", "farm", "rent", "gnpr", "labo",
-                  "inst", "ecks", "death", "demostab",
-                  "dictator")]
-
- fit.mfa = FactoMineR::MFA(df, , group = c(3, 2, 5), ncp = 2,
-               type = rep("s", 3),
-               graph = FALSE)
-
- X_agric = as.matrix(Russett[,c("gini","farm","rent")])
- X_ind = as.matrix(Russett[,c("gnpr","labo")])
- X_polit = as.matrix(Russett[ , c("inst", "ecks", "death",
-                                  "demostab", "dictator")])
-
- A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
- A = lapply(A, scale)
- n = sqrt(sapply(A, function(x) eigen(RGCCA:::cov2(x, bias = TRUE))$values[1]))
- for (j in 1:3){A[[j]] = A[[j]]/n[j]}
-
-
- A_withSB = c(A, list(Reduce("cbind", A)))
-
- # Recovering MFA with weighted pca on "superblock" : Tout OK
- fit.mfaViaPca= rgcca(list(A_withSB[[4]]),method="pca",scale=FALSE,scale_block=FALSE,ncomp=2)
- cor(fit.mfaViaPca$Y[[1]][, 1], fit.mfa$global.pca$ind$coord[, 1]) #-1 OK
- cor(fit.mfaViaPca$Y[[1]][, 2], fit.mfa$global.pca$ind$coord[, 2]) #-1 OK
- head(cbind(fit.mfaViaPca$Y[[1]][, 1], fit.mfa$global.pca$ind$coord[, 1]))
- head(cbind(fit.mfaViaPca$Y[[1]][, 2], fit.mfa$global.pca$ind$coord[, 2]))
-
-
- # Recovering MFA with rgcca with "manual superblock"
- C = matrix(c(0, 0, 0, 1,
-              0, 0, 0, 1,
-              0, 0, 0, 1,
-              1, 1, 1, 0), 4, 4)
-
- fit.rgcca = rgcca(blocks = A_withSB, connection = C,
-                  tau = c(rep(1, 3), 0),
-                  scheme = "factorial",
-                  scale = FALSE,
-                  scale_block = FALSE,
-                  verbose = FALSE,
-                  bias = FALSE, ncomp = 2)
-
- # Recovering MFA with rgcca and "automatic" superblock (with tau = 1)
- fit.sbTau1  = rgcca(blocks = A,
-                  tau = rep(1, 4),
-                  scheme = "factorial",
-                  scale = FALSE,
-                  scale_block = FALSE,
-                  verbose = FALSE,
-                  bias = FALSE, ncomp = 2,
-                  superblock = TRUE)
-
- # Recovering MFA  with rgcca and "automatic" superblock (with tau = 0)
- fit.sbTau0 = rgcca(blocks = A,
-                   tau = c(1,1,1,0),
-                   scheme = "factorial",
-                   scale = FALSE,
-                   scale_block = FALSE,
-                   verbose = FALSE,
-                   bias = FALSE, ncomp = 2,
-                   superblock = TRUE)
-
- # Recovering MFA with 'mcoa'
- fit.mcoa = rgcca(blocks = A, method = "mcoa",
-                   scale = FALSE,
-                   scale_block = FALSE,
-                   verbose = FALSE,
-                   bias = TRUE, ncomp = 2)
-
- # 1 pour tout le monde
- cor1=cor(fit.rgcca$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
- cor2=cor(fit.sbTau0$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
- cor3=cor(fit.sbTau1$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
- cor4=cor(fit.mcoa$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
-
-
- test_that("rgccaVsMFA",{expect_true( round(cor1,digits=8)==1)})
- test_that("superblockTau0VsMFA",{expect_true( round(cor2,digits=8)==1)})
- test_that("superblockTau1vsMFA",{expect_true( round(cor3,digits=8)==1)})
- test_that("mcoaVsMFA",{expect_true( round(cor4,digits=8)==1)})
-
- matY=cbind(rgcca=fit.rgcca$Y[[4]][,1],sbtau0=fit.sbTau0$Y[[4]][,1],sbtau1=fit.sbTau1$Y[[4]][,1],mcoa=fit.mcoa$Y[[4]][,1], mfa=fit.mfa$global.pca$ind$coord[, 1])
-
- test_that("superblockTau1vsMFA_egalite",{expect_true(  sum(round(abs(matY[,"sbtau1"]-matY[,"mfa"]),digits=8))==0)})
-
- cor1_2=cor(fit.rgcca$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2]) # pas 1 dans ce cas
- cor2_2=cor(fit.sbTau0$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2])
- cor3_2=cor(fit.sbTau1$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2])
- cor4_2=cor(fit.mcoa$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2])
-
-
- test_that("superblockTau0VsMFA_comp2",{expect_true( round(cor2_2,digits=8)==1)})
- test_that("superblockTau1vsMFA_comp2",{expect_true( round(cor3_2,digits=8)==1)})
- test_that("mcoaVsMFA_comp2",{expect_true( round(cor4_2,digits=8)==1)})
-
- matY_2=cbind(rgcca=fit.rgcca$Y[[4]][,2],sbtau0=fit.sbTau0$Y[[4]][,2],sbtau1=fit.sbTau1$Y[[4]][,2],mcoa=fit.mcoa$Y[[4]][,2], mfa=fit.mfa$global.pca$ind$coord[, 2])
- test_that("superblockTau1vsMFA_egalite_comp2",{expect_true(  sum(round(abs(matY_2[,"sbtau1"]-matY_2[,"mfa"]),digits=8))==0)})
-
-
-
- # Recovering PCA with superblock
- resPCA_sb= rgcca (
-     blocks=list(gini=X_agric[,"gini"],farm=X_agric[,"farm"],rent=X_agric[,"rent"]),
-     superblock = TRUE,
-     tau =c(1,1,1,0),
-     ncomp = 2,
-     method = "rgcca",
-     verbose = FALSE,
-     scheme = "factorial",
-     scale = TRUE,
-     init = "svd",
-     bias = TRUE,
-     tol = 1e-08)
-
- resPCA=rgcca(list(X_agric),method="pca",ncomp=2)
- # Comment déflate t'on si on a deux composantes que dans le superbloc ?
- cbind(resPCA$Y[[1]],resPCA_sb$Y[[4]])
- cor_pca1=cor(resPCA$Y[[1]][,1],resPCA_sb$Y[[4]][,1])
- cor_pca2=cor(resPCA$Y[[1]][,2],resPCA_sb$Y[[4]][,2])
- test_that("PCA_superblockVsPCA_comp1",{expect_true( round(abs(cor_pca1),digits=8)==1)})
- test_that("PCA_superblockVsPCA_comp2",{expect_true( round(abs(cor_pca1),digits=8)==1)})
-
-
- # sgcca with superblock and 2 components
- A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
-
- fit.sgcca = rgcca(blocks = A,
-                    sparsity = c(0.7,0.8,0.8,0.5),
-                    scheme = "factorial",
-                    scale = FALSE,
-                    scale_block = FALSE,
-                    verbose = FALSE,
-                    bias = FALSE, ncomp = 2,
-                    superblock = TRUE)
-
- # test superblock
- A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
-A[[1]][1:5,]=NA
-resrgcca=rgcca(A,method="cpca-2",ncomp=2)
-t(resrgcca$Y[[4]])%*%resrgcca$Y[[4]]
-
+X_agric = as.matrix(Russett[, c("gini","farm","rent")]);
+X_ind = as.matrix(Russett[, c("gnpr","labo")]);
+X_polit = as.matrix(Russett[, c("demostab", "dictator")]);
+
+##### Retrieve scaled PCA with RGCCA #####
+X = Russett[, seq(5)]
+fit.pca = prcomp(X, scale = TRUE)
+
+test_that("RGCCA is equivalent to scaled PCA with duplicated X and default
+          parameters", {
+              fit.rgcca = rgcca(list(X, X))
+              if (sign(fit.rgcca$a[[1]][1]) != sign(fit.pca$rotation[1]))
+                  fit.rgcca$a[[1]] = -fit.rgcca$a[[1]]
+              expect_true(sum(abs(fit.pca$rotation[, 1] - fit.rgcca$a[[1]])) < tol)
+          })
+
+test_that("RGCCA is equivalent to scaled PCA with columns split into blocks
+          and connected to a superblock", {
+              A = list(X[, 1], X[, 2], X[, 3], X[, 4], X[, 5])
+              fit.rgcca = rgcca(blocks = A, superblock = TRUE, tau = 0,
+                                scheme = "factorial")
+              if (sign(fit.rgcca$Y[[6]][1]) != sign(fit.pca$x[1]))
+                  fit.rgcca$Y[[6]] = -fit.rgcca$Y[[6]]
+              expect_equal(cor(fit.rgcca$Y[[6]], fit.pca$x[, 1])[1], 1,
+                           tolerance = tol)
+          })
+
+test_that("RGCCA is equivalent to scaled PCA when method = 'pca'", {
+    fit.rgcca = rgcca(list(X), method = "pca", ncomp = 2)
+    if (sign(fit.rgcca$a[[1]][1, 1]) != sign(fit.pca$rotation[1, 1]))
+        fit.rgcca$a[[1]][, 1] = -fit.rgcca$a[[1]][, 1]
+    expect_true(sum(abs(fit.pca$rotation[, 1] - fit.rgcca$a[[1]][, 1])) < tol)
+    if (sign(fit.rgcca$a[[1]][1, 2]) != sign(fit.pca$rotation[1, 2]))
+        fit.rgcca$a[[1]][, 2] = -fit.rgcca$a[[1]][, 2]
+    expect_true(sum(abs(fit.pca$rotation[, 2] - fit.rgcca$a[[1]][, 2])) < tol)
+})
+
+##### Retrieve unscaled PCA with RGCCA #####
+X = Russett[, seq(5)]
+fit.pca = prcomp(X, scale = FALSE)
+
+test_that("RGCCA is equivalent to unscaled PCA with duplicated X and default
+          parameters", {
+              fit.rgcca = rgcca(list(X, X), scale = FALSE, scale_block = FALSE)
+              if (sign(fit.rgcca$a[[1]][1]) != sign(fit.pca$rotation[1]))
+                  fit.rgcca$a[[1]] = -fit.rgcca$a[[1]]
+              expect_true(sum(abs(fit.pca$rotation[, 1] - fit.rgcca$a[[1]])) < tol)
+          })
+
+test_that("RGCCA is equivalent to unscaled PCA with columns split into blocks
+          and connected to a superblock", {
+              A = list(X[, 1], X[, 2], X[, 3], X[, 4], X[, 5])
+              fit.rgcca = rgcca(blocks = A, superblock = TRUE, tau = 0,
+                                scheme = "factorial", scale = FALSE,
+                                scale_block = FALSE)
+              if (sign(fit.rgcca$Y[[6]][1]) != sign(fit.pca$x[1]))
+                  fit.rgcca$Y[[6]] = -fit.rgcca$Y[[6]]
+              expect_equal(cor(fit.rgcca$Y[[6]], fit.pca$x[, 1])[1], 1,
+                           tolerance = 1e-5)
+          })
+
+test_that("RGCCA is equivalent to unscaled PCA when method = 'pca'", {
+    fit.rgcca = rgcca(list(X), method = "pca", ncomp = 2, scale = FALSE,
+                      scale_block = FALSE)
+    if (sign(fit.rgcca$a[[1]][1, 1]) != sign(fit.pca$rotation[1, 1]))
+        fit.rgcca$a[[1]][, 1] = -fit.rgcca$a[[1]][, 1]
+    expect_true(sum(abs(fit.pca$rotation[, 1] - fit.rgcca$a[[1]][, 1])) < tol)
+    if (sign(fit.rgcca$a[[1]][1, 2]) != sign(fit.pca$rotation[1, 2]))
+        fit.rgcca$a[[1]][, 2] = -fit.rgcca$a[[1]][, 2]
+    expect_true(sum(abs(fit.pca$rotation[, 2] - fit.rgcca$a[[1]][, 2])) < tol)
+})
+
+##### Retrieve PLS with RGCCA #####
+A = list(agriculture = X_agric, industry = X_ind)
+fit.svd = svd(t(scale(X_agric)) %*% scale(X_ind))
+
+test_that("RGCCA is equivalent to PLS when there are two blocks and tau = 1", {
+    fit.rgcca = rgcca(blocks = A, scale = TRUE, scale_block = FALSE,
+                      bias = FALSE, scheme = "horst", tol = 1e-16)
+    expect_true(sum(abs(fit.svd$u[, 1] - fit.rgcca$a[[1]])) < 1e-9)
+    expect_true(sum(abs(fit.svd$v[, 1] - fit.rgcca$a[[2]])) < 1e-9)
+})
+
+test_that("RGCCA is equivalent to PLS when method = 'pls'", {
+    fit.rgcca = rgcca(blocks = A, method = "pls", scale = TRUE,
+                      scale_block = FALSE, tol = 1e-16, bias = FALSE)
+    expect_true(sum(abs(fit.svd$u[, 1] - fit.rgcca$a[[1]][, 1])) < 1e-9)
+    expect_true(sum(abs(fit.svd$v[, 1] - fit.rgcca$a[[2]][, 1])) < 1e-9)
+})
+
+##### Retrieve CCA with RGCCA #####
+Sigma_11 = cov(X_agric)
+Sigma_12 = cov(X_agric, X_ind)
+Sigma_22 = cov(X_ind)
+
+sqrt_matrix = function(M){
+    eig        = eigen(M)
+    M_sqrt     = eig$vectors %*% diag(sqrt(eig$values)) %*% t(eig$vectors)
+    Minv_sqrt  = eig$vectors %*% diag(eig$values^(-1/2)) %*% t(eig$vectors)
+    return(list(M_sqrt = M_sqrt, Minv_sqrt = Minv_sqrt))
+}
+
+fit.svd = svd(sqrt_matrix(Sigma_11)[[2]] %*% Sigma_12 %*% sqrt_matrix(Sigma_22)[[2]])
+
+test_that("RGCCA is equivalent to CCA when there are two blocks and tau = 0", {
+    fit.rgcca = rgcca(blocks = A, scale = FALSE, tau = 0, scheme = "horst",
+                      scale_block = FALSE, tol = 1e-16, bias = FALSE)
+    expect_true(sum(abs(fit.svd$u[, 1] - sqrt_matrix(Sigma_11)[[1]] %*% fit.rgcca$a[[1]])) < 1e-8)
+    expect_true(sum(abs(fit.svd$v[, 1] - sqrt_matrix(Sigma_22)[[1]] %*% fit.rgcca$a[[2]])) < 1e-8)
+})
+
+test_that("RGCCA is equivalent to CCA when method = 'cca'", {
+    fit.rgcca = rgcca(blocks = A, method = "cca", scale = FALSE,
+                      scale_block = FALSE, tol = 1e-16, bias = FALSE)
+    expect_true(sum(abs(fit.svd$u[, 1] - sqrt_matrix(Sigma_11)[[1]] %*% fit.rgcca$a[[1]])) < 1e-8)
+    expect_true(sum(abs(fit.svd$v[, 1] - sqrt_matrix(Sigma_22)[[1]] %*% fit.rgcca$a[[2]])) < 1e-8)
+})
+
+##### Perform OLS with RGCCA #####
+y = Russett[, 4]
+fit.lm = lm(y~as.matrix(X_agric))
+r2_ols = summary(fit.lm)$r.squared
+
+test_that("The criterion of RGCCA is the R-squared for the OLS problem", {
+    fit.rgcca = rgcca(blocks = list(y, X_agric), scheme = "factorial",
+                      tau = 0, tol = 1e-16, bias = FALSE)
+    crit_rgcca = fit.rgcca$crit[length(fit.rgcca$crit)] / 2
+    expect_equal(r2_ols, crit_rgcca, tolerance = tol)
+})
+
+##### Verify theoretical relations between superblock and block components #####
 A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
-#resrgcca5dim=rgcca(A,method="cpca-2",ncomp=5)
+J = length(A)
+fit = rgcca(blocks = A, tau = 1, scheme = "factorial", scale = FALSE,
+            scale_block = FALSE, bias = FALSE, ncomp = 1, superblock = TRUE)
 
+test_that("Block weights can be retrieved using the superblock component", {
+    for (j in seq_len(J)) {
+        a = t(A[[j]]) %*% fit$Y[[J + 1]]
+        if (sign(a[1]) != sign(fit$a[[j]][1])) a = -a
+        expect_true(max(abs(fit$a[[j]] - a / norm(a, type = "2"))) < tol)
+    }
+})
+
+test_that("Block weights can be retrieved using the superblock weights", {
+    idx = c(0, cumsum(sapply(A, ncol)))
+    for (j in seq_len(J)) {
+        a = fit$a[[J + 1]][seq(1 + idx[j], idx[j + 1])]
+        if (sign(a[1]) != sign(fit$a[[j]][1])) a = -a
+        expect_true(max(abs(fit$a[[j]] - a / norm(a, type = "2"))) < tol)
+    }
+})
+
+##### Retrieve MFA with RGCCA #####
+df = Russett[, c("gini", "farm", "rent", "gnpr", "labo",
+                 "inst", "ecks",  "death", "demostab", "dictator")]
+fit.mfa = MFA(df, group = c(3, 2, 5), ncp = 2, type = rep("s", 3),
+              graph = FALSE)
+
+X_agric = Russett[,c("gini","farm","rent")]
+X_ind = Russett[,c("gnpr","labo")]
+X_polit = Russett[ , c("inst", "ecks",  "death",
+                       "demostab", "dictator")]
+A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
+
+test_that("RGCCA is equivalent to MFA with right parameters", {
+    fit.mcoa = rgcca(blocks = A, tau = 1, scheme = "factorial", scale = TRUE,
+                     scale_block = "lambda1", bias = TRUE, ncomp = 2,
+                     superblock = TRUE, tol = 1e-16)
+
+    expect_true(max(abs(fit.mcoa$Y[[4]][, 1] - fit.mfa$ind$coord[, 1])) < tol)
+    expect_true(max(abs(fit.mcoa$Y[[4]][, 2] - fit.mfa$ind$coord[, 2])) < tol)
+})

--- a/tests/testthat/test_rgcca.R
+++ b/tests/testthat/test_rgcca.R
@@ -346,6 +346,15 @@ test_that("upca_var2",{expect_true(upca_var)})
  test_that("PCA_superblockVsPCA_comp2",{expect_true( round(abs(cor_pca1),digits=8)==1)})
  
  
- 
- 
+ # sgcca with superblock and 2 components
+ A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
+
+ fit.sgcca = rgcca(blocks = A,
+                    sparsity = c(0.7,0.8,0.8,0.5),
+                    scheme = "factorial",
+                    scale = FALSE,
+                    scale_block = FALSE,
+                    verbose = FALSE,
+                    bias = FALSE, ncomp = 2,
+                    superblock = TRUE)
 

--- a/tests/testthat/test_rgcca.R
+++ b/tests/testthat/test_rgcca.R
@@ -1,4 +1,3 @@
-library(cluster)
 library(FactoMineR)
 
 tol = 1e-14

--- a/tests/testthat/test_rgcca.R
+++ b/tests/testthat/test_rgcca.R
@@ -291,7 +291,6 @@ test_that("upca_var2",{expect_true(upca_var)})
                    verbose = FALSE,
                    bias = TRUE, ncomp = 2)
  
- fit.mcoa$call$superblock
  # 1 pour tout le monde
  cor1=cor(fit.rgcca$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
  cor2=cor(fit.sbTau0$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
@@ -357,4 +356,13 @@ test_that("upca_var2",{expect_true(upca_var)})
                     verbose = FALSE,
                     bias = FALSE, ncomp = 2,
                     superblock = TRUE)
+
+ # test superblock
+ A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
+A[[1]][1:5,]=NA 
+resrgcca=rgcca(A,method="cpca-2",ncomp=2)
+t(resrgcca$Y[[4]])%*%resrgcca$Y[[4]]
+
+A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
+#resrgcca5dim=rgcca(A,method="cpca-2",ncomp=5)
 

--- a/tests/testthat/test_rgcca.R
+++ b/tests/testthat/test_rgcca.R
@@ -216,46 +216,46 @@ test_that("upca_var2",{expect_true(upca_var)})
 
  resSgcca = rgcca(A, method="sgcca",superblock=TRUE)
 
- 
+
 # Recovering MFA
 
 
- 
+
  df = Russett[, c("gini", "farm", "rent", "gnpr", "labo",
                   "inst", "ecks", "death", "demostab",
                   "dictator")]
- 
+
  fit.mfa = FactoMineR::MFA(df, , group = c(3, 2, 5), ncp = 2,
                type = rep("s", 3),
                graph = FALSE)
- 
+
  X_agric = as.matrix(Russett[,c("gini","farm","rent")])
  X_ind = as.matrix(Russett[,c("gnpr","labo")])
  X_polit = as.matrix(Russett[ , c("inst", "ecks", "death",
                                   "demostab", "dictator")])
- 
+
  A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
  A = lapply(A, scale)
  n = sqrt(sapply(A, function(x) eigen(RGCCA:::cov2(x, bias = TRUE))$values[1]))
  for (j in 1:3){A[[j]] = A[[j]]/n[j]}
- 
- 
+
+
  A_withSB = c(A, list(Reduce("cbind", A)))
- 
+
  # Recovering MFA with weighted pca on "superblock" : Tout OK
  fit.mfaViaPca= rgcca(list(A_withSB[[4]]),method="pca",scale=FALSE,scale_block=FALSE,ncomp=2)
  cor(fit.mfaViaPca$Y[[1]][, 1], fit.mfa$global.pca$ind$coord[, 1]) #-1 OK
  cor(fit.mfaViaPca$Y[[1]][, 2], fit.mfa$global.pca$ind$coord[, 2]) #-1 OK
  head(cbind(fit.mfaViaPca$Y[[1]][, 1], fit.mfa$global.pca$ind$coord[, 1]))
  head(cbind(fit.mfaViaPca$Y[[1]][, 2], fit.mfa$global.pca$ind$coord[, 2]))
- 
- 
+
+
  # Recovering MFA with rgcca with "manual superblock"
  C = matrix(c(0, 0, 0, 1,
               0, 0, 0, 1,
               0, 0, 0, 1,
               1, 1, 1, 0), 4, 4)
- 
+
  fit.rgcca = rgcca(blocks = A_withSB, connection = C,
                   tau = c(rep(1, 3), 0),
                   scheme = "factorial",
@@ -263,7 +263,7 @@ test_that("upca_var2",{expect_true(upca_var)})
                   scale_block = FALSE,
                   verbose = FALSE,
                   bias = FALSE, ncomp = 2)
- 
+
  # Recovering MFA with rgcca and "automatic" superblock (with tau = 1)
  fit.sbTau1  = rgcca(blocks = A,
                   tau = rep(1, 4),
@@ -273,7 +273,7 @@ test_that("upca_var2",{expect_true(upca_var)})
                   verbose = FALSE,
                   bias = FALSE, ncomp = 2,
                   superblock = TRUE)
- 
+
  # Recovering MFA  with rgcca and "automatic" superblock (with tau = 0)
  fit.sbTau0 = rgcca(blocks = A,
                    tau = c(1,1,1,0),
@@ -283,51 +283,51 @@ test_that("upca_var2",{expect_true(upca_var)})
                    verbose = FALSE,
                    bias = FALSE, ncomp = 2,
                    superblock = TRUE)
- 
+
  # Recovering MFA with 'mcoa'
  fit.mcoa = rgcca(blocks = A, method = "mcoa",
                    scale = FALSE,
                    scale_block = FALSE,
                    verbose = FALSE,
                    bias = TRUE, ncomp = 2)
- 
+
  # 1 pour tout le monde
  cor1=cor(fit.rgcca$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
  cor2=cor(fit.sbTau0$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
  cor3=cor(fit.sbTau1$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
  cor4=cor(fit.mcoa$Y[[4]][, 1], fit.mfa$global.pca$ind$coord[, 1])
 
- 
+
  test_that("rgccaVsMFA",{expect_true( round(cor1,digits=8)==1)})
  test_that("superblockTau0VsMFA",{expect_true( round(cor2,digits=8)==1)})
  test_that("superblockTau1vsMFA",{expect_true( round(cor3,digits=8)==1)})
  test_that("mcoaVsMFA",{expect_true( round(cor4,digits=8)==1)})
- 
+
  matY=cbind(rgcca=fit.rgcca$Y[[4]][,1],sbtau0=fit.sbTau0$Y[[4]][,1],sbtau1=fit.sbTau1$Y[[4]][,1],mcoa=fit.mcoa$Y[[4]][,1], mfa=fit.mfa$global.pca$ind$coord[, 1])
- 
+
  test_that("superblockTau1vsMFA_egalite",{expect_true(  sum(round(abs(matY[,"sbtau1"]-matY[,"mfa"]),digits=8))==0)})
- 
+
  cor1_2=cor(fit.rgcca$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2]) # pas 1 dans ce cas
  cor2_2=cor(fit.sbTau0$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2])
  cor3_2=cor(fit.sbTau1$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2])
  cor4_2=cor(fit.mcoa$Y[[4]][, 2], fit.mfa$global.pca$ind$coord[, 2])
- 
+
 
  test_that("superblockTau0VsMFA_comp2",{expect_true( round(cor2_2,digits=8)==1)})
  test_that("superblockTau1vsMFA_comp2",{expect_true( round(cor3_2,digits=8)==1)})
  test_that("mcoaVsMFA_comp2",{expect_true( round(cor4_2,digits=8)==1)})
- 
+
  matY_2=cbind(rgcca=fit.rgcca$Y[[4]][,2],sbtau0=fit.sbTau0$Y[[4]][,2],sbtau1=fit.sbTau1$Y[[4]][,2],mcoa=fit.mcoa$Y[[4]][,2], mfa=fit.mfa$global.pca$ind$coord[, 2])
  test_that("superblockTau1vsMFA_egalite_comp2",{expect_true(  sum(round(abs(matY_2[,"sbtau1"]-matY_2[,"mfa"]),digits=8))==0)})
- 
 
- 
+
+
  # Recovering PCA with superblock
  resPCA_sb= rgcca (
      blocks=list(gini=X_agric[,"gini"],farm=X_agric[,"farm"],rent=X_agric[,"rent"]),
      superblock = TRUE,
      tau =c(1,1,1,0),
-     ncomp = c(1,1,1,2),
+     ncomp = 2,
      method = "rgcca",
      verbose = FALSE,
      scheme = "factorial",
@@ -343,8 +343,8 @@ test_that("upca_var2",{expect_true(upca_var)})
  cor_pca2=cor(resPCA$Y[[1]][,2],resPCA_sb$Y[[4]][,2])
  test_that("PCA_superblockVsPCA_comp1",{expect_true( round(abs(cor_pca1),digits=8)==1)})
  test_that("PCA_superblockVsPCA_comp2",{expect_true( round(abs(cor_pca1),digits=8)==1)})
- 
- 
+
+
  # sgcca with superblock and 2 components
  A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
 
@@ -359,7 +359,7 @@ test_that("upca_var2",{expect_true(upca_var)})
 
  # test superblock
  A = list(Agric = X_agric, Ind = X_ind, Polit = X_polit)
-A[[1]][1:5,]=NA 
+A[[1]][1:5,]=NA
 resrgcca=rgcca(A,method="cpca-2",ncomp=2)
 t(resrgcca$Y[[4]])%*%resrgcca$Y[[4]]
 

--- a/tests/testthat/test_scaling.r
+++ b/tests/testthat/test_scaling.r
@@ -4,8 +4,49 @@ blocks <- list(
     industry = Russett[, 4:5],
     politic = Russett[, 6:11])
 
-blocks3=lapply(blocks,scale)
-blocks3=lapply(blocks3,function(x) return(x/sqrt(ncol(x))))
-blocks2=RGCCA:::scaling(blocks,scale=TRUE,scale_block=TRUE,bias=FALSE)
+bias = FALSE
+sqrt_N = sqrt(NROW(blocks[[1]]) + bias - 1)
+
+blocks3 = lapply(blocks, scale)
+blocks3 = lapply(blocks3, function(x) return(x/sqrt(ncol(x))))
+blocks2 = scaling(blocks, scale = T, scale_block = T, bias = bias)
 test_that("scaling_default_1", {
-    expect_true(sum(abs(blocks3[[2]]-blocks2[[2]]))<3e-15)})
+    expect_true(sum(abs(blocks3[[2]] - blocks2[[2]])) < 1e-14)})
+
+test_that("scale_block = 'inertia' leads to unit Frobenius norm", {
+  b = scaling(blocks, scale = T, scale_block = T, bias = bias)
+  for (j in seq_along(b)) {
+    expect_equal(norm(b[[j]] / sqrt_N, type = "F"), 1, tolerance = 1e-14)
+  }
+  b = scaling(blocks, scale = F, scale_block = T, bias = bias)
+  for (j in seq_along(b)) {
+    expect_equal(norm(b[[j]] / sqrt_N, type = "F"), 1, tolerance = 1e-14)
+  }
+})
+
+test_that("scale_block = 'lambda1' leads to top eigenvalue of covariance
+          matrix being equal to one", {
+            b = scaling(blocks, scale = T, scale_block = "lambda1", bias = bias)
+            for (j in seq_along(b)) {
+              expect_equal(eigen(crossprod(b[[j]] / sqrt_N))$values[1],
+                           1, tolerance = 1e-14)
+            }
+            b = scaling(blocks, scale = F, scale_block = "lambda1", bias = bias)
+            for (j in seq_along(b)) {
+              expect_equal(eigen(crossprod(b[[j]] / sqrt_N))$values[1],
+                           1, tolerance = 1e-14)
+            }
+})
+
+test_that("another value of scale_block does not lead to further scaling", {
+  b = scaling(blocks, scale = T, scale_block = "none", bias = bias)
+  b_ref = lapply(blocks, scale)
+  for (j in seq_along(b)) {
+    expect_true(sum(abs(b[[j]] - b_ref[[j]])) < 1e-14)
+  }
+  b = scaling(blocks, scale = F, scale_block = "none", bias = bias)
+  b_ref = lapply(blocks, scale, center = T, scale = F)
+  for (j in seq_along(b)) {
+    expect_true(sum(abs(b[[j]] - b_ref[[j]])) < 1e-14)
+  }
+})


### PR DESCRIPTION
This PR aims to change the way superblock is handled to retrieve classical methods of the literature. After this PR,
- when `superblock = TRUE`, deflation is performed on the superblock, and regular blocks are retrieved from the deflated superblock;
- as a consequence of the previous point, `astar` is no longer meaningful for the regular blocks, so when a superblock is used, `astar` is not a list but a matrix associated with the `astar` of the superblock;
- `scale_block` behavior changed to enable a new option: `scale_block = "lambda1"`. This option scales each block by the first eigenvalue of its empirical covariance matrix. `scale_block = "inertia"` or `scale_block = TRUE` gives the same result as before (i.e., the block is divided by the sum of its empirical covariance matrix's eigenvalues). Any other value of `scale_block` leaves the block unchanged.

Tests to compare RGCCA with other methods from the literature have been updated in `test_rgcca.R`.