### PR TITLE
Fix/for missing values

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -337,7 +337,7 @@ check_spars <- function(sparsity, block, n) {
   }
   min_sparsity <- 1 / sqrt(NCOL(block))
   min_message <- paste0(
-    "too high sparsity. Sparsity parameter equals ", sparsity,
+    "too low sparsity. Sparsity parameter equals ", sparsity,
     ". For SGCCA, it must be greater than ",
     "1/sqrt(number_column) (i.e., ", round(min_sparsity, 4),
     " for block ", n, ")."

--- a/R/format_combinations.R
+++ b/R/format_combinations.R
@@ -1,0 +1,15 @@
+#' Small utility function to format a matrix of parameters
+#' @noRd
+format_combinations <- function(par_value) {
+  combinations <- apply(
+    format(par_value, digits = 2), 1, paste0, collapse = "/"
+  )
+  # If parameters are too long, there are replaced with "Set x"
+  # The same is done if rounding to 2 digits leads to the same values
+  to_set <- (nchar(combinations[1]) > 15) |
+    (length(unique(combinations)) < NROW(par_value))
+  if (to_set) {
+    combinations <- paste("Set ", sep = "", seq_len(NROW(par_value)))
+  }
+  return(combinations)
+}

--- a/R/plot.rgcca.R
+++ b/R/plot.rgcca.R
@@ -261,9 +261,7 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
         df_cor(x, block[1], comp, num_block)
       )
 
-      title <- ifelse(
-        missing(title), toupper(names(x$blocks)[block[1]]), title
-      )
+      title <- ifelse(missing(title), "", title)
       plot_function <- plot_both
     },
     # Plot percentage of AVE per component and per block. If some blocks are not
@@ -328,6 +326,6 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
     cex_main, cex_sub, cex_point, colors, shapes,
     show_labels, repel
   )
-  if (!is.null(p)) plot(p, ...)
+  if (is(p, "ggplot")) plot(p, ...)
   invisible(p)
 }

--- a/R/plot.rgcca.R
+++ b/R/plot.rgcca.R
@@ -28,6 +28,8 @@
 #' @param show_labels A logical value for showing the labels in plots "samples"
 #' and "cor_circle".
 #' @param repel A logical value for repelling text labels from each other.
+#' @param display_blocks A numeric corresponding to the block(s) to display in
+#' the correlation_circle.
 #' @param ... additional graphical parameters
 #' @details
 #' \itemize{
@@ -44,7 +46,10 @@
 #' in decreasing correlations and only the highest
 #' correlations are displayed. The number of displayed correlations can be set
 #' with n_marks (defaut value = 30).
-#' \item  "cor_circle" for correlation circle.
+#' \item  "cor_circle" for correlation circle. It represents the correlation
+#' between the component corresponding to the first element of the block
+#' argument, and the variables of the block corresponding to the blocks
+#' specified by the argument display_blocks.
 #' \item "both": displays both sample plot and correlation circle (implemented
 #' only for one block and at least when two components are asked (ncomp >= 2).
 #' \item "ave": displays the average variance explained for each block.}
@@ -97,7 +102,8 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
                        cex_main = 14 * cex, cex_lab = 12 * cex,
                        cex_point = 3 * cex, n_mark = 30,
                        colors = NULL, shapes = NULL,
-                       show_labels = TRUE, repel = FALSE, ...) {
+                       show_labels = TRUE, repel = FALSE,
+                       display_blocks = seq_along(x$call$blocks), ...) {
   ### Define data.frame generating functions
   df_sample <- function(x, block, comp, response) {
     data.frame(
@@ -107,22 +113,23 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
     )
   }
 
-  df_cor <- function(x, block, comp, num_block) {
+  df_cor <- function(x, block, comp, num_block, display_blocks) {
     df <- data.frame(
-      x = do.call(rbind, lapply(block, function(j) {
+      x = do.call(rbind, Map(function(i, j) {
         cor(
-          x$blocks[[j]][rownames(x$Y[[j]]), ],
+          x$blocks[[i]][rownames(x$Y[[j]]), ],
           x$Y[[j]][, comp],
           use = "pairwise.complete.obs"
         )
-      })),
+      }, display_blocks, block)),
       response = num_block,
-      y = do.call(c, lapply(x$blocks[block], colnames))
+      y = do.call(c, lapply(x$blocks[display_blocks], colnames))
     )
 
     idx <- apply(do.call(
-      rbind, lapply(x$a[block], function(z) z[, comp[1], drop = FALSE])),
-      1, function(y) any(y != 0))
+      rbind,
+      lapply(x$a[display_blocks], function(z) z[, comp, drop = FALSE])
+    ), 1, function(y) any(y != 0))
     return(df[idx, ])
   }
 
@@ -179,15 +186,27 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
   comp <- elongate_arg(comp, seq(2))[seq(2)]
   block <- elongate_arg(block, seq(2))
 
+  lapply(display_blocks, function(i) {
+    check_blockx("display_blocks", i, x$call$blocks)
+  })
+
+  response_block <- FALSE
+
   switch(type,
     "samples" = {
       block <- block[seq(2)]
+      display_blocks <- block
     },
     "cor_circle" = {
-      block <- block[1]
+      block <- ifelse(x$call$superblock, length(x$call$blocks) + 1, block[1])
+      response_block <- !is.null(x$call$response) && (block == x$call$response)
     },
     "both" = {
-      block <- rep(block[1], 2)
+      block <- rep(ifelse(
+        x$call$superblock, length(x$call$blocks) + 1, block[1]
+      ), 2)
+      response_block <- !is.null(x$call$response) &&
+        (block[1] == x$call$response)
     },
     "ave" = {
       comp <- 1
@@ -195,12 +214,21 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
     "loadings" = {
       block <- unique(block)
       comp <- comp[1]
+      display_blocks <- block
     },
     "weights" = {
       block <- unique(block)
       comp <- comp[1]
+      display_blocks <- block
     }
   )
+
+  if (response_block) {
+    stop_rgcca(
+      "Drawing a correlation circle with block = ", block ,
+      " is not allowed, because the response components are not orthogonal."
+    )
+  }
 
   lapply(block, function(i) {
     check_blockx("block", i, x$blocks)
@@ -232,9 +260,8 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
       function(j) rep(names(x$blocks)[j], NCOL(x$blocks[[j]]))
     )))
   } else {
-    max_length <- ifelse(type == "both", 1, length(block))
     num_block <- as.factor(unlist(lapply(
-      block[seq(max_length)],
+      display_blocks,
       function(j) rep(names(x$blocks)[j], NCOL(x$blocks[[j]]))
     )))
   }
@@ -248,7 +275,7 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
     },
     # Plot block columns on a correlation circle
     "cor_circle" = {
-      df <- df_cor(x, block[1], comp, num_block)
+      df <- df_cor(x, block[1], comp, num_block, display_blocks)
 
       title <- ifelse(missing(title), "Correlation circle", title)
       plot_function <- plot_cor_circle
@@ -258,7 +285,7 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
     "both" = {
       df <- list(
         df_sample(x, block, comp, response),
-        df_cor(x, block[1], comp, num_block)
+        df_cor(x, block[1], comp, num_block, display_blocks)
       )
 
       title <- ifelse(missing(title), "", title)
@@ -280,7 +307,7 @@ plot.rgcca <- function(x, type = "weights", block = seq_along(x$call$blocks),
     },
     # Plot the value associated with each individual in the projected space
     "loadings" = {
-      df <- df_cor(x, block, comp, num_block)
+      df <- df_cor(x, block, comp, num_block, display_blocks)
       if (display_order) {
         df <- df[order(abs(df[, 1]), decreasing = TRUE), ]
       }

--- a/R/plot_both.R
+++ b/R/plot_both.R
@@ -19,9 +19,8 @@ plot_both <- function(df, title, x, block, comp, theme_RGCCA,
       cex_main, cex_sub, cex_point, colors, shapes, show_labels,
       repel
     ),
-    nrow = 1, ncol = 2
-  ) +
-    theme_RGCCA
+    nrow = 1, ncol = 2, top = title
+  )
 
   invisible(p)
 }

--- a/R/remove_null_sd.R
+++ b/R/remove_null_sd.R
@@ -23,7 +23,8 @@ remove_null_sd <- function(list_m, column_sd_null = NULL) {
       function(x) {
         which(apply(x, 2, function(y) {
           if (mode(y) != "character") {
-            res <- all(is.na(y)) || (sd(y[!is.na(y)]) == 0)
+            std <- sd(y, na.rm = TRUE)
+            res <- is.na(std) || (std == 0)
           } else {
             res <- FALSE
           }

--- a/R/rgcca_bootstrap.R
+++ b/R/rgcca_bootstrap.R
@@ -144,8 +144,10 @@ rgcca_bootstrap <- function(rgcca_res, n_boot = 100,
     n_cores = n_cores, verbose = verbose
   )
 
+  W <- W[!vapply(W, is.null, logical(1L))]
+
   res <- format_bootstrap_list(W, rgcca_res)
-  stats <- rgcca_bootstrap_stats(res, rgcca_res, n_boot)
+  stats <- rgcca_bootstrap_stats(res, rgcca_res, length(W))
 
   return(structure(list(
     n_boot = n_boot, rgcca = rgcca_res,

--- a/R/rgcca_bootstrap_k.R
+++ b/R/rgcca_bootstrap_k.R
@@ -64,6 +64,6 @@ rgcca_bootstrap_k <- function(rgcca_res, inds = NULL, type = "loadings") {
     names(L) <- names(rgcca_res$a)
     return(list(W = A, L = L))
   } else {
-    return(list(W = missing_var, L = missing_var))
+    return(NULL)
   }
 }

--- a/R/rgcca_cv.r
+++ b/R/rgcca_cv.r
@@ -239,13 +239,7 @@ rgcca_cv <- function(blocks,
   )
 
   # Compute statistics
-  combinations <- apply(
-    format(param$par_value, digits = 2), 1, paste0, collapse = "/"
-  )
-  # If parameters are too long, there are replaced with "Set x"
-  if (nchar(combinations[1]) > 15) {
-    combinations <- paste("Set ", sep = "", seq_len(NROW(param$par_value)))
-  }
+  combinations <- format_combinations(param$par_value)
 
   stats <- data.frame(
     combinations,

--- a/R/rgcca_cv.r
+++ b/R/rgcca_cv.r
@@ -239,12 +239,12 @@ rgcca_cv <- function(blocks,
   )
 
   # Compute statistics
-  if (length(rgcca_args$blocks) > 5) {
+  combinations <- apply(
+    format(param$par_value, digits = 2), 1, paste0, collapse = "/"
+  )
+  # If parameters are too long, there are replaced with "Set x"
+  if (nchar(combinations[1]) > 15) {
     combinations <- paste("Set ", sep = "", seq_len(NROW(param$par_value)))
-  } else {
-    combinations <- apply(
-      format(param$par_value, digits = 2), 1, paste0, collapse = "/"
-    )
   }
 
   stats <- data.frame(

--- a/R/rgcca_permutation.R
+++ b/R/rgcca_permutation.R
@@ -324,13 +324,14 @@ rgcca_permutation <- function(blocks, par_type = "tau", par_value = NULL,
     },
     FUN.VALUE = double(1)
   )
-  if (length(rgcca_args$blocks) > 5) {
+  combinations <- apply(
+    format(param$par_value, digits = 2), 1, paste0, collapse = "/"
+  )
+  # If parameters are too long, there are replaced with "Set x"
+  if (nchar(combinations[1]) > 15) {
     combinations <- paste("Set ", sep = "", seq_len(NROW(param$par_value)))
-  } else {
-    combinations <- apply(
-      format(param$par_value, digits = 2), 1, paste0, collapse = "/"
-    )
   }
+
   stats <- data.frame(
     combinations = combinations,
     crit = crit,

--- a/R/rgcca_permutation.R
+++ b/R/rgcca_permutation.R
@@ -324,13 +324,7 @@ rgcca_permutation <- function(blocks, par_type = "tau", par_value = NULL,
     },
     FUN.VALUE = double(1)
   )
-  combinations <- apply(
-    format(param$par_value, digits = 2), 1, paste0, collapse = "/"
-  )
-  # If parameters are too long, there are replaced with "Set x"
-  if (nchar(combinations[1]) > 15) {
-    combinations <- paste("Set ", sep = "", seq_len(NROW(param$par_value)))
-  }
+  combinations <- format_combinations(param$par_value)
 
   stats <- data.frame(
     combinations = combinations,

--- a/R/rgcca_permutation.R
+++ b/R/rgcca_permutation.R
@@ -276,15 +276,24 @@ rgcca_permutation <- function(blocks, par_type = "tau", par_value = NULL,
     rgcca_args$response, rgcca_args$superblock, opt$disjunction
   )
 
+  ### Create folds
+  v_inds <- lapply(seq_len(n_perms), function(i) {
+    lapply(rgcca_args$blocks, function(x) {
+      sample(seq_len(NROW(x)))
+    })
+  })
+
   ### Start line search
   # For every set of parameter, RGCCA is run once on the non permuted blocks
   # and then n_perms on permuted blocks.
   idx <- seq(NROW(param$par_value) * (n_perms + 1))
   W <- par_pblapply(idx, function(n) {
     i <- (n - 1) %/% (n_perms + 1) + 1
+    j <- (n - 1) %% (n_perms + 1)
     perm <- (n - 1) %% (n_perms + 1) != 0
     rgcca_permutation_k(
       rgcca_args,
+      inds = v_inds[[j]],
       par_type = param$par_type,
       par_value = param$par_value[i, ],
       perm = perm

--- a/R/rgcca_permutation_k.R
+++ b/R/rgcca_permutation_k.R
@@ -5,13 +5,16 @@
 #' by concatenating the permuted blocks.
 #' @inheritParams rgcca_permutation
 #' @noRd
-rgcca_permutation_k <- function(rgcca_args, perm, par_type, par_value) {
+rgcca_permutation_k <- function(rgcca_args, inds, perm, par_type, par_value) {
   if (perm) {
-    rgcca_args$blocks <- lapply(rgcca_args$blocks, function(x) {
-      block <- as.matrix(x)[sample(seq_len(NROW(x))), , drop = FALSE]
+    blocks <- lapply(seq_along(rgcca_args$blocks), function(i) {
+      x <- rgcca_args$blocks[[i]]
+      block <- as.matrix(x)[inds[[i]], , drop = FALSE]
       rownames(block) <- rownames(x)
       return(block)
     })
+    names(blocks) <- names(rgcca_args$blocks)
+    rgcca_args$blocks <- blocks
   }
 
   rgcca_args[[par_type]] <- par_value

--- a/R/rgcca_predict.R
+++ b/R/rgcca_predict.R
@@ -156,7 +156,7 @@ rgcca_predict <- function(rgcca_res,
     res[["prediction"]]$test[, "pred"]
   }))
 
-  score <- mean(unlist(lapply(results, "[[", "score")))
+  score <- mean(unlist(lapply(results, "[[", "score")), na.rm = TRUE)
   names(score) <- names(results[[1]][["score"]])
 
   result <- list(

--- a/R/rgcca_stability.R
+++ b/R/rgcca_stability.R
@@ -92,6 +92,8 @@ rgcca_stability <- function(rgcca_res,
     n_cores = n_cores, verbose = verbose
   )
 
+  W <- W[!vapply(W, is.null, logical(1L))]
+
   res <- format_bootstrap_list(W, rgcca_res)
   J <- length(rgcca_res$blocks)
 

--- a/R/scale2.R
+++ b/R/scale2.R
@@ -10,9 +10,6 @@ scale2 <- function(A, scale = TRUE, bias = TRUE) {
   if (scale) {
     A <- scale(A, center = TRUE, scale = FALSE)
     std <- sqrt(apply(A, 2, function(x) cov2(x, bias = bias)))
-    if (any(std == 0)) {
-      sprintf("there were %d constant variables", sum(std == 0))
-    }
     A <- sweep(A, 2, std, FUN = "/")
     attr(A, "scaled:scale") <- std
     return(A)

--- a/R/set_parameter_grid.R
+++ b/R/set_parameter_grid.R
@@ -118,8 +118,6 @@ set_parameter_grid <- function(par_type, par_length, par_value, blocks,
 
   if (par_type == "ncomp") {
     param$par_value <- round(param$par_value)
-  } else {
-    param$par_value <- round(param$par_value, digits = 2)
   }
   param$par_value <-
     param$par_value[!duplicated(param$par_value), , drop = FALSE]

--- a/man/plot.rgcca.Rd
+++ b/man/plot.rgcca.Rd
@@ -22,6 +22,7 @@
   shapes = NULL,
   show_labels = TRUE,
   repel = FALSE,
+  display_blocks = seq_along(x$call$blocks),
   ...
 )
 }
@@ -70,6 +71,9 @@ and "cor_circle".}
 
 \item{repel}{A logical value for repelling text labels from each other.}
 
+\item{display_blocks}{A numeric corresponding to the block(s) to display in
+the correlation_circle.}
+
 \item{...}{additional graphical parameters}
 }
 \value{
@@ -93,7 +97,10 @@ weights can be set with n_marks.
 in decreasing correlations and only the highest
 correlations are displayed. The number of displayed correlations can be set
 with n_marks (defaut value = 30).
-\item  "cor_circle" for correlation circle.
+\item  "cor_circle" for correlation circle. It represents the correlation
+between the component corresponding to the first element of the block
+argument, and the variables of the block corresponding to the blocks
+specified by the argument display_blocks.
 \item "both": displays both sample plot and correlation circle (implemented
 only for one block and at least when two components are asked (ncomp >= 2).
 \item "ave": displays the average variance explained for each block.}

--- a/tests/testthat/_snaps/plot.cval/cv-many-blocks.svg
+++ b/tests/testthat/_snaps/plot.cval/cv-many-blocks.svg
@@ -20,49 +20,49 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDYuMzJ8NzE0LjUyfDMzLjE0fDU0MS4zNQ=='>
-    <rect x='46.32' y='33.14' width='668.20' height='508.21' />
+  <clipPath id='cpNDUuMjV8NzE0LjUyfDMzLjE0fDU0MS4zNQ=='>
+    <rect x='45.25' y='33.14' width='669.27' height='508.21' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDYuMzJ8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='68.00,541.35 68.00,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='269.46,541.35 269.46,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='470.91,541.35 470.91,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='672.36,541.35 672.36,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.32,402.75 714.52,402.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='46.32,171.74 714.52,171.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='168.73,541.35 168.73,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='370.18,541.35 370.18,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='571.64,541.35 571.64,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='350.18' y1='402.75' x2='358.55' y2='402.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='110.65' y1='402.75' x2='76.69' y2='402.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polygon points='350.18,506.70 110.65,506.70 110.65,298.80 350.18,298.80 350.18,506.70 ' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<line x1='230.42' y1='506.70' x2='230.42' y2='298.80' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='644.46' y1='171.74' x2='679.89' y2='171.74' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='283.99' y1='171.74' x2='233.72' y2='171.74' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='644.46,275.70 283.99,275.70 283.99,67.79 644.46,67.79 644.46,275.70 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='464.22' y1='275.70' x2='464.22' y2='67.79' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<circle cx='282.18' cy='366.42' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='606.16' cy='144.91' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='356.76' cy='382.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='684.15' cy='130.55' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='317.89' cy='385.55' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='412.15' cy='216.20' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='80.60' cy='367.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='234.34' cy='190.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='127.32' cy='409.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='389.43' cy='206.19' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<g clip-path='url(#cpNDUuMjV8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
+<polyline points='98.80,541.35 98.80,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='294.59,541.35 294.59,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.39,541.35 490.39,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='686.18,541.35 686.18,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='45.25,402.75 714.52,402.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='45.25,171.74 714.52,171.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='196.70,541.35 196.70,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='392.49,541.35 392.49,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.28,541.35 588.28,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='498.02' y1='402.75' x2='623.53' y2='402.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='92.09' y1='402.75' x2='75.67' y2='402.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='498.02,506.70 92.09,506.70 92.09,298.80 498.02,298.80 498.02,506.70 ' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<line x1='295.06' y1='506.70' x2='295.06' y2='298.80' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='549.48' y1='171.74' x2='679.96' y2='171.74' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='164.87' y1='171.74' x2='163.39' y2='171.74' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='549.48,275.70 164.87,275.70 164.87,67.79 549.48,67.79 549.48,275.70 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='357.18' y1='275.70' x2='357.18' y2='67.79' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='236.67' cy='366.42' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='290.33' cy='144.91' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='621.78' cy='382.00' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='684.10' cy='130.55' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='84.34' cy='385.55' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='161.05' cy='216.20' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='318.97' cy='367.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='328.35' cy='190.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='225.82' cy='409.48' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='327.03' cy='206.19' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='18.97' y='405.72' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 1</text>
-<polyline points='18.97,406.48 41.39,406.48 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='18.97' y='175.05' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 2</text>
-<text x='168.73' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.4</text>
-<text x='370.18' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.6</text>
-<text x='571.64' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='380.42' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='68.04px' lengthAdjust='spacingAndGlyphs'>Mean RMSE</text>
+<text x='18.97' y='405.85' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>1/1/1</text>
+<polyline points='18.97,406.60 40.32,406.60 ' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='18.97' y='175.18' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>2/2/2</text>
+<text x='196.70' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='392.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='588.28' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='379.89' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='68.04px' lengthAdjust='spacingAndGlyphs'>Mean RMSE</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='167.43px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (ncomp)</text>
-<text x='46.32' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='262.24px' lengthAdjust='spacingAndGlyphs'>Cross-validated RMSE (kfold: with 5 folds)</text>
-<text x='46.32' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='143.20px' lengthAdjust='spacingAndGlyphs'>Best parameters: Set 1</text>
+<text x='45.25' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='262.24px' lengthAdjust='spacingAndGlyphs'>Cross-validated RMSE (kfold: with 5 folds)</text>
+<text x='45.25' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='141.65px' lengthAdjust='spacingAndGlyphs'>Best parameters: 1/1/1</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.cval/cv-quantile.svg
+++ b/tests/testthat/_snaps/plot.cval/cv-quantile.svg
@@ -20,138 +20,138 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ=='>
-    <rect x='85.29' y='33.14' width='629.23' height='508.21' />
+  <clipPath id='cpNTEuNjZ8NzE0LjUyfDMzLjE0fDU0MS4zNQ=='>
+    <rect x='51.66' y='33.14' width='662.86' height='508.21' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='223.46,541.35 223.46,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='411.40,541.35 411.40,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='599.34,541.35 599.34,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,361.98 714.52,361.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,312.16 714.52,312.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,262.33 714.52,262.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,212.51 714.52,212.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='129.49,541.35 129.49,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='317.43,541.35 317.43,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='505.37,541.35 505.37,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='693.31,541.35 693.31,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='472.77' y1='511.46' x2='670.80' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='142.58' y1='511.46' x2='127.75' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polygon points='472.77,533.88 142.58,533.88 142.58,489.03 472.77,489.03 472.77,533.88 ' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<line x1='265.82' y1='533.88' x2='265.82' y2='489.03' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='473.36' y1='461.63' x2='670.43' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='144.01' y1='461.63' x2='128.15' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='473.36,484.05 144.01,484.05 144.01,439.21 473.36,439.21 473.36,484.05 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='267.98' y1='484.05' x2='267.98' y2='439.21' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='474.11' y1='411.81' x2='669.75' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='146.37' y1='411.81' x2='128.86' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='474.11,434.23 146.37,434.23 146.37,389.39 474.11,389.39 474.11,434.23 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='270.31' y1='434.23' x2='270.31' y2='389.39' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='475.33' y1='361.98' x2='669.14' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='148.72' y1='361.98' x2='129.46' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='475.33,384.40 148.72,384.40 148.72,339.56 475.33,339.56 475.33,384.40 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='274.98' y1='384.40' x2='274.98' y2='339.56' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='476.43' y1='312.16' x2='668.27' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='151.63' y1='312.16' x2='130.32' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='476.43,334.58 151.63,334.58 151.63,289.74 476.43,289.74 476.43,334.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='278.62' y1='334.58' x2='278.62' y2='289.74' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='477.84' y1='262.33' x2='666.65' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='156.87' y1='262.33' x2='131.99' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='477.84,284.75 156.87,284.75 156.87,239.91 477.84,239.91 477.84,284.75 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='282.70' y1='284.75' x2='282.70' y2='239.91' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='479.54' y1='212.51' x2='664.80' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='162.45' y1='212.51' x2='133.80' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='479.54,234.93 162.45,234.93 162.45,190.09 479.54,190.09 479.54,234.93 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='287.93' y1='234.93' x2='287.93' y2='190.09' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='483.08' y1='162.68' x2='661.62' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='171.00' y1='162.68' x2='136.41' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='483.08,185.11 171.00,185.11 171.00,140.26 483.08,140.26 483.08,185.11 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='299.21' y1='185.11' x2='299.21' y2='140.26' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='486.59' y1='112.86' x2='654.60' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='191.00' y1='112.86' x2='143.03' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='486.59,135.28 191.00,135.28 191.00,90.44 486.59,90.44 486.59,135.28 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='308.16' y1='135.28' x2='308.16' y2='90.44' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='491.62' y1='63.04' x2='642.41' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='213.26' y1='63.04' x2='153.48' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='491.62,85.46 213.26,85.46 213.26,40.61 491.62,40.61 491.62,85.46 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='320.65' y1='85.46' x2='320.65' y2='40.61' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<circle cx='137.75' cy='509.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='157.56' cy='465.02' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='131.52' cy='417.29' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='140.61' cy='365.80' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='151.77' cy='307.68' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='160.63' cy='256.85' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='176.47' cy='207.97' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='175.63' cy='165.29' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='199.90' cy='103.54' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='228.62' cy='55.20' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='136.42' cy='502.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='113.89' cy='457.98' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='147.43' cy='403.46' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='136.48' cy='356.23' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='128.70' cy='306.36' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='123.41' cy='261.04' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='134.48' cy='205.15' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='132.04' cy='171.40' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='160.04' cy='106.22' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='159.20' cy='66.56' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='259.33' cy='520.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='279.90' cy='465.69' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='254.28' cy='415.62' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='291.31' cy='358.83' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='273.10' cy='314.02' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='266.00' cy='270.70' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='293.52' cy='221.86' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='305.14' cy='156.89' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='311.44' cy='113.50' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='332.67' cy='67.94' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='685.92' cy='510.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='683.57' cy='469.44' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='684.93' cy='418.87' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='666.21' cy='370.09' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='651.93' cy='317.03' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='669.69' cy='255.42' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='648.69' cy='211.95' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='672.39' cy='154.13' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='639.78' cy='117.26' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='649.50' cy='68.85' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='491.12' cy='503.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='477.48' cy='459.47' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='468.86' cy='404.67' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='487.06' cy='367.92' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='473.40' cy='305.01' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='469.60' cy='252.53' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='481.01' cy='211.24' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='466.72' cy='170.16' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='477.43' cy='113.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='488.85' cy='60.93' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<g clip-path='url(#cpNTEuNjZ8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
+<polyline points='197.17,541.35 197.17,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='395.17,541.35 395.17,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='593.17,541.35 593.17,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,361.98 714.52,361.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,312.16 714.52,312.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,262.33 714.52,262.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,212.51 714.52,212.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='98.17,541.35 98.17,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='296.17,541.35 296.17,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.17,541.35 494.17,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='692.17,541.35 692.17,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='459.83' y1='511.46' x2='668.47' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='111.96' y1='511.46' x2='96.34' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='459.83,533.88 111.96,533.88 111.96,489.03 459.83,489.03 459.83,533.88 ' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<line x1='241.80' y1='533.88' x2='241.80' y2='489.03' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='460.53' y1='461.63' x2='668.02' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='113.65' y1='461.63' x2='96.81' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='460.53,484.05 113.65,484.05 113.65,439.21 460.53,439.21 460.53,484.05 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='244.34' y1='484.05' x2='244.34' y2='439.21' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='461.37' y1='411.81' x2='667.45' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='115.75' y1='411.81' x2='97.40' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='461.37,434.23 115.75,434.23 115.75,389.39 461.37,389.39 461.37,434.23 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='247.30' y1='434.23' x2='247.30' y2='389.39' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='462.39' y1='361.98' x2='666.70' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='118.41' y1='361.98' x2='98.16' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='462.39,384.40 118.41,384.40 118.41,339.56 462.39,339.56 462.39,384.40 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='250.78' y1='384.40' x2='250.78' y2='339.56' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='463.64' y1='312.16' x2='665.68' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='121.86' y1='312.16' x2='99.18' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='463.64,334.58 121.86,334.58 121.86,289.74 463.64,289.74 463.64,334.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='254.94' y1='334.58' x2='254.94' y2='289.74' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='465.23' y1='262.33' x2='664.24' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='126.49' y1='262.33' x2='100.60' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='465.23,284.75 126.49,284.75 126.49,239.91 465.23,239.91 465.23,284.75 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='260.02' y1='284.75' x2='260.02' y2='239.91' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='467.28' y1='212.51' x2='662.09' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='132.92' y1='212.51' x2='102.67' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='467.28,234.93 132.92,234.93 132.92,190.09 467.28,190.09 467.28,234.93 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='266.34' y1='234.93' x2='266.34' y2='190.09' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='470.03' y1='162.68' x2='658.60' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='142.47' y1='162.68' x2='105.94' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='470.03,185.11 142.47,185.11 142.47,140.26 470.03,140.26 470.03,185.11 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='274.45' y1='185.11' x2='274.45' y2='140.26' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='473.91' y1='112.86' x2='652.30' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='160.77' y1='112.86' x2='111.63' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='473.91,135.28 160.77,135.28 160.77,90.44 473.91,90.44 473.91,135.28 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='285.15' y1='135.28' x2='285.15' y2='90.44' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='479.68' y1='63.04' x2='638.56' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='186.42' y1='63.04' x2='123.45' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='479.68,85.46 186.42,85.46 186.42,40.61 479.68,40.61 479.68,85.46 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='299.56' y1='85.46' x2='299.56' y2='40.61' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='106.87' cy='509.45' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='127.93' cy='465.02' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='100.10' cy='417.29' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='109.86' cy='365.80' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='122.01' cy='307.68' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='130.46' cy='256.85' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='147.69' cy='207.97' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='147.35' cy='165.29' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='170.14' cy='103.54' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='202.60' cy='55.20' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='105.47' cy='502.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='81.79' cy='457.98' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='116.96' cy='403.46' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='105.56' cy='356.23' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='97.48' cy='306.36' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='91.56' cy='261.04' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='103.39' cy='205.15' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='101.33' cy='171.40' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='129.55' cy='106.22' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='129.47' cy='66.56' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='234.96' cy='520.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='256.90' cy='465.69' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='230.41' cy='415.62' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='267.99' cy='358.83' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='249.12' cy='314.02' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='242.42' cy='270.70' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='272.23' cy='221.86' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='280.70' cy='156.89' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='288.60' cy='113.50' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='312.23' cy='67.94' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='684.39' cy='510.67' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='681.86' cy='469.44' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='683.44' cy='418.87' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='663.62' cy='370.09' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='648.46' cy='317.03' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='667.44' cy='255.42' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='645.12' cy='211.95' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='669.96' cy='154.13' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='636.69' cy='117.26' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='646.02' cy='68.85' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='479.16' cy='503.08' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='464.86' cy='459.47' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='455.83' cy='404.67' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='474.74' cy='367.92' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='460.46' cy='305.01' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='456.55' cy='252.53' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='468.83' cy='211.24' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='452.80' cy='170.16' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='464.26' cy='113.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='476.77' cy='60.93' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.20/0.30</text>
-<polyline points='18.97,515.31 80.36,515.31 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
-<text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.11/0.17</text>
-<text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.16/0.23</text>
-<text x='18.97' y='465.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.18/0.27</text>
-<text x='18.97' y='365.42' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.13/0.20</text>
-<text x='18.97' y='215.94' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.07/0.10</text>
-<text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.09/0.13</text>
-<text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.04/0.07</text>
-<text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.02/0.03</text>
-<text x='129.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='317.43' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='505.37' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='693.31' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.1</text>
-<text x='399.91' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='59.37px' lengthAdjust='spacingAndGlyphs'>Mean MAE</text>
+<text x='24.31' y='514.43' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 1</text>
+<polyline points='24.31,515.18 46.73,515.18 ' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='18.97' y='66.34' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='27.76px' lengthAdjust='spacingAndGlyphs'>Set 10</text>
+<text x='24.31' y='315.46' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 5</text>
+<text x='24.31' y='415.11' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 3</text>
+<text x='24.31' y='464.94' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 2</text>
+<text x='24.31' y='365.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 4</text>
+<text x='24.31' y='215.81' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 7</text>
+<text x='24.31' y='265.64' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 6</text>
+<text x='24.31' y='165.99' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 8</text>
+<text x='24.31' y='116.17' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 9</text>
+<text x='98.17' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='296.17' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='494.17' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='692.17' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='383.09' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='59.37px' lengthAdjust='spacingAndGlyphs'>Mean MAE</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='148.08px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (tau)</text>
-<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='252.13px' lengthAdjust='spacingAndGlyphs'>Cross-validated MAE (kfold: with 5 folds)</text>
-<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='200.04px' lengthAdjust='spacingAndGlyphs'>Best parameters: 0.00/0.20/0.30</text>
+<text x='51.66' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='252.13px' lengthAdjust='spacingAndGlyphs'>Cross-validated MAE (kfold: with 5 folds)</text>
+<text x='51.66' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='143.20px' lengthAdjust='spacingAndGlyphs'>Best parameters: Set 1</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.cval/cv-sd.svg
+++ b/tests/testthat/_snaps/plot.cval/cv-sd.svg
@@ -20,138 +20,138 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ=='>
-    <rect x='85.29' y='33.14' width='629.23' height='508.21' />
+  <clipPath id='cpNTEuNjZ8NzE0LjUyfDMzLjE0fDU0MS4zNQ=='>
+    <rect x='51.66' y='33.14' width='662.86' height='508.21' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='233.27,541.35 233.27,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='419.99,541.35 419.99,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='606.70,541.35 606.70,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,361.98 714.52,361.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,312.16 714.52,312.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,262.33 714.52,262.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,212.51 714.52,212.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='85.29,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='139.92,541.35 139.92,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='326.63,541.35 326.63,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='513.34,541.35 513.34,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='700.06,541.35 700.06,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='576.16' y1='511.46' x2='677.70' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='113.89' y1='511.46' x2='138.19' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polygon points='576.16,533.88 113.89,533.88 113.89,489.03 576.16,489.03 576.16,533.88 ' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<line x1='345.02' y1='533.88' x2='345.02' y2='489.03' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='576.40' y1='461.63' x2='677.33' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='115.32' y1='461.63' x2='138.58' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='576.40,484.05 115.32,484.05 115.32,439.21 576.40,439.21 576.40,484.05 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='345.86' y1='484.05' x2='345.86' y2='439.21' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='576.54' y1='411.81' x2='676.65' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='117.35' y1='411.81' x2='139.29' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='576.54,434.23 117.35,434.23 117.35,389.39 576.54,389.39 576.54,434.23 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='346.95' y1='434.23' x2='346.95' y2='389.39' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='577.18' y1='361.98' x2='676.04' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='119.98' y1='361.98' x2='139.89' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='577.18,384.40 119.98,384.40 119.98,339.56 577.18,339.56 577.18,384.40 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='348.58' y1='384.40' x2='348.58' y2='339.56' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='577.51' y1='312.16' x2='675.19' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='122.69' y1='312.16' x2='140.74' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='577.51,334.58 122.69,334.58 122.69,289.74 577.51,289.74 577.51,334.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='350.10' y1='334.58' x2='350.10' y2='289.74' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='577.55' y1='262.33' x2='673.57' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='126.93' y1='262.33' x2='142.40' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='577.55,284.75 126.93,284.75 126.93,239.91 577.55,239.91 577.55,284.75 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='352.24' y1='284.75' x2='352.24' y2='239.91' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='577.73' y1='212.51' x2='671.74' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='131.71' y1='212.51' x2='144.19' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='577.73,234.93 131.71,234.93 131.71,190.09 577.73,190.09 577.73,234.93 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='354.72' y1='234.93' x2='354.72' y2='190.09' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='578.63' y1='162.68' x2='668.57' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='139.86' y1='162.68' x2='146.79' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='578.63,185.11 139.86,185.11 139.86,140.26 578.63,140.26 578.63,185.11 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='359.25' y1='185.11' x2='359.25' y2='140.26' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='577.00' y1='112.86' x2='661.60' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='154.24' y1='112.86' x2='153.37' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='577.00,135.28 154.24,135.28 154.24,90.44 577.00,90.44 577.00,135.28 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='365.62' y1='135.28' x2='365.62' y2='90.44' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='573.56' y1='63.04' x2='649.50' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='172.80' y1='63.04' x2='163.75' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='573.56,85.46 172.80,85.46 172.80,40.61 573.56,40.61 573.56,85.46 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='373.18' y1='85.46' x2='373.18' y2='40.61' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
-<circle cx='160.61' cy='513.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='152.60' cy='464.77' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='167.68' cy='406.12' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='175.54' cy='363.64' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='165.43' cy='316.01' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='185.27' cy='267.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='164.23' cy='203.72' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='169.09' cy='158.31' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='210.81' cy='106.02' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='225.11' cy='61.33' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='124.75' cy='503.13' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='151.33' cy='466.11' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='142.99' cy='417.32' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='130.84' cy='370.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='148.48' cy='321.42' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='142.96' cy='258.28' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='137.38' cy='206.61' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='157.34' cy='167.11' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='166.81' cy='113.93' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='161.76' cy='69.59' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='259.56' cy='508.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='270.21' cy='470.87' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='290.01' cy='418.24' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='267.27' cy='355.24' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='295.45' cy='314.28' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='306.49' cy='257.94' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='287.83' cy='212.83' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='306.17' cy='160.26' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='334.52' cy='118.44' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='343.04' cy='69.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='681.62' cy='515.26' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='665.57' cy='465.63' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='685.92' cy='405.87' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='682.73' cy='356.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='678.10' cy='319.88' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='657.43' cy='258.28' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='678.21' cy='202.80' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='657.66' cy='154.40' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='656.91' cy='112.96' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='648.20' cy='57.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='475.02' cy='505.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='473.31' cy='466.89' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='495.19' cy='410.30' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='481.46' cy='364.39' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='472.24' cy='303.13' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='471.59' cy='260.01' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='477.10' cy='211.59' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='499.12' cy='162.98' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='511.46' cy='120.68' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
-<circle cx='514.89' cy='61.15' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<g clip-path='url(#cpNTEuNjZ8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
+<polyline points='207.53,541.35 207.53,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.19,541.35 404.19,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='600.86,541.35 600.86,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,361.98 714.52,361.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,312.16 714.52,312.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,262.33 714.52,262.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,212.51 714.52,212.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='51.66,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='109.20,541.35 109.20,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='305.86,541.35 305.86,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='502.53,541.35 502.53,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='699.19,541.35 699.19,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='568.69' y1='511.46' x2='675.64' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='81.79' y1='511.46' x2='107.38' y2='511.46' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='568.69,533.88 81.79,533.88 81.79,489.03 568.69,489.03 568.69,533.88 ' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<line x1='325.24' y1='533.88' x2='325.24' y2='489.03' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='568.97' y1='461.63' x2='675.20' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='83.47' y1='461.63' x2='107.85' y2='461.63' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='568.97,484.05 83.47,484.05 83.47,439.21 568.97,439.21 568.97,484.05 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='326.22' y1='484.05' x2='326.22' y2='439.21' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='569.29' y1='411.81' x2='674.63' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='85.51' y1='411.81' x2='108.43' y2='411.81' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='569.29,434.23 85.51,434.23 85.51,389.39 569.29,389.39 569.29,434.23 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='327.40' y1='434.23' x2='327.40' y2='389.39' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='569.63' y1='361.98' x2='673.89' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='88.02' y1='361.98' x2='109.19' y2='361.98' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='569.63,384.40 88.02,384.40 88.02,339.56 569.63,339.56 569.63,384.40 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='328.82' y1='384.40' x2='328.82' y2='339.56' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='569.98' y1='312.16' x2='672.87' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='91.18' y1='312.16' x2='110.20' y2='312.16' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='569.98,334.58 91.18,334.58 91.18,289.74 569.98,289.74 569.98,334.58 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='330.58' y1='334.58' x2='330.58' y2='289.74' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='570.33' y1='262.33' x2='671.44' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='95.31' y1='262.33' x2='111.61' y2='262.33' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='570.33,284.75 95.31,284.75 95.31,239.91 570.33,239.91 570.33,284.75 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='332.82' y1='284.75' x2='332.82' y2='239.91' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='570.60' y1='212.51' x2='669.31' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='100.90' y1='212.51' x2='113.67' y2='212.51' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='570.60,234.93 100.90,234.93 100.90,190.09 570.60,190.09 570.60,234.93 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='335.75' y1='234.93' x2='335.75' y2='190.09' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='570.59' y1='162.68' x2='665.84' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='108.92' y1='162.68' x2='116.91' y2='162.68' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='570.59,185.11 108.92,185.11 108.92,140.26 570.59,140.26 570.59,185.11 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='339.76' y1='185.11' x2='339.76' y2='140.26' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='569.76' y1='112.86' x2='659.59' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='122.58' y1='112.86' x2='122.57' y2='112.86' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='569.76,135.28 122.58,135.28 122.58,90.44 569.76,90.44 569.76,135.28 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='346.17' y1='135.28' x2='346.17' y2='90.44' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='565.95' y1='63.04' x2='645.93' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='143.84' y1='63.04' x2='134.31' y2='63.04' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='565.95,85.46 143.84,85.46 143.84,40.61 565.95,40.61 565.95,85.46 ' style='stroke-width: 1.07; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='354.89' y1='85.46' x2='354.89' y2='40.61' style='stroke-width: 2.13; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='131.00' cy='513.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='122.75' cy='464.77' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='138.24' cy='406.12' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='146.70' cy='363.64' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='136.44' cy='316.01' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='156.46' cy='267.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='134.83' cy='203.72' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='140.49' cy='158.31' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='181.68' cy='106.02' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='198.93' cy='61.33' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='93.22' cy='503.13' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='121.27' cy='466.11' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='112.33' cy='417.32' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='99.66' cy='370.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='118.36' cy='321.42' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='112.20' cy='258.28' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='106.49' cy='206.61' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='128.02' cy='167.11' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='136.73' cy='113.93' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='132.21' cy='69.59' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='235.22' cy='508.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='246.71' cy='470.87' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='268.06' cy='418.24' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='242.68' cy='355.24' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='272.68' cy='314.28' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='285.07' cy='257.94' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='266.23' cy='212.83' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='281.80' cy='160.26' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='312.93' cy='118.44' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='323.14' cy='69.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='679.77' cy='515.26' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='662.82' cy='465.63' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='684.39' cy='405.87' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='680.93' cy='356.18' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='675.94' cy='319.88' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='654.44' cy='258.28' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='676.13' cy='202.80' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='654.35' cy='154.40' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='654.65' cy='112.96' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='644.57' cy='57.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='462.16' cy='505.92' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='460.43' cy='466.89' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='483.53' cy='410.30' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='468.80' cy='364.39' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='459.19' cy='303.13' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='458.61' cy='260.01' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='464.66' cy='211.59' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='486.89' cy='162.98' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='500.07' cy='120.68' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='504.15' cy='61.15' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.20/0.30</text>
-<polyline points='18.97,515.31 80.36,515.31 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
-<text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.11/0.17</text>
-<text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.16/0.23</text>
-<text x='18.97' y='465.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.18/0.27</text>
-<text x='18.97' y='365.42' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.13/0.20</text>
-<text x='18.97' y='215.94' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.07/0.10</text>
-<text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.09/0.13</text>
-<text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.04/0.07</text>
-<text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.02/0.03</text>
-<text x='139.92' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<text x='326.63' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
-<text x='513.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='700.06' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.1</text>
-<text x='399.91' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='59.37px' lengthAdjust='spacingAndGlyphs'>Mean MAE</text>
+<text x='24.31' y='514.43' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 1</text>
+<polyline points='24.31,515.18 46.73,515.18 ' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='18.97' y='66.34' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='27.76px' lengthAdjust='spacingAndGlyphs'>Set 10</text>
+<text x='24.31' y='315.46' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 5</text>
+<text x='24.31' y='415.11' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 3</text>
+<text x='24.31' y='464.94' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 2</text>
+<text x='24.31' y='365.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 4</text>
+<text x='24.31' y='215.81' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 7</text>
+<text x='24.31' y='265.64' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 6</text>
+<text x='24.31' y='165.99' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 8</text>
+<text x='24.31' y='116.17' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 9</text>
+<text x='109.20' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='305.86' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='502.53' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='699.19' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.1</text>
+<text x='383.09' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='59.37px' lengthAdjust='spacingAndGlyphs'>Mean MAE</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='148.08px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (tau)</text>
-<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='252.13px' lengthAdjust='spacingAndGlyphs'>Cross-validated MAE (kfold: with 5 folds)</text>
-<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='200.04px' lengthAdjust='spacingAndGlyphs'>Best parameters: 0.00/0.20/0.30</text>
+<text x='51.66' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='252.13px' lengthAdjust='spacingAndGlyphs'>Cross-validated MAE (kfold: with 5 folds)</text>
+<text x='51.66' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='143.20px' lengthAdjust='spacingAndGlyphs'>Best parameters: Set 1</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.permutation/permutation-crit.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-crit.svg
@@ -25,11 +25,11 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='156.57,541.35 156.57,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='278.42,541.35 278.42,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='400.27,541.35 400.27,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.12,541.35 522.12,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='643.97,541.35 643.97,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='156.53,541.35 156.53,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='278.39,541.35 278.39,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='400.25,541.35 400.25,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='522.11,541.35 522.11,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='643.96,541.35 643.96,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
@@ -40,61 +40,61 @@
 <polyline points='85.29,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='95.64,541.35 95.64,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='217.49,541.35 217.49,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='339.34,541.35 339.34,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='461.19,541.35 461.19,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='583.04,541.35 583.04,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='95.61,541.35 95.61,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='217.46,541.35 217.46,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='339.32,541.35 339.32,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='461.18,541.35 461.18,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='583.03,541.35 583.03,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='704.89,541.35 704.89,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='291.74' y1='511.46' x2='329.92' y2='511.46' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='215.37' y1='511.46' x2='177.19' y2='511.46' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='291.74,530.14 215.37,530.14 215.37,492.77 291.74,492.77 291.74,530.14 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='253.56' y1='530.14' x2='253.56' y2='492.77' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='191.34' y1='461.63' x2='194.98' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='184.07' y1='461.63' x2='180.44' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='191.34,480.32 184.07,480.32 184.07,442.95 191.34,442.95 191.34,480.32 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='187.71' y1='480.32' x2='187.71' y2='442.95' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='167.21' y1='411.81' x2='173.28' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='155.05' y1='411.81' x2='148.98' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='167.21,430.49 155.05,430.49 155.05,393.12 167.21,393.12 167.21,430.49 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='161.13' y1='430.49' x2='161.13' y2='393.12' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='135.45' y1='361.98' x2='141.42' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='123.50' y1='361.98' x2='117.53' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='135.45,380.67 123.50,380.67 123.50,343.30 135.45,343.30 135.45,380.67 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='129.48' y1='380.67' x2='129.48' y2='343.30' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='140.42' y1='312.16' x2='143.66' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='133.96' y1='312.16' x2='130.72' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='140.42,330.84 133.96,330.84 133.96,293.47 140.42,293.47 140.42,330.84 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='137.19' y1='330.84' x2='137.19' y2='293.47' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='154.21' y1='262.33' x2='165.10' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='132.44' y1='262.33' x2='121.56' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='154.21,281.02 132.44,281.02 132.44,243.65 154.21,243.65 154.21,281.02 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='143.33' y1='281.02' x2='143.33' y2='243.65' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='145.84' y1='212.51' x2='154.90' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='127.72' y1='212.51' x2='118.66' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='145.84,231.19 127.72,231.19 127.72,193.82 145.84,193.82 145.84,231.19 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='136.78' y1='231.19' x2='136.78' y2='193.82' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='126.91' y1='162.68' x2='131.24' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='118.23' y1='162.68' x2='113.89' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='126.91,181.37 118.23,181.37 118.23,144.00 126.91,144.00 126.91,181.37 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='122.57' y1='181.37' x2='122.57' y2='144.00' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='154.03' y1='112.86' x2='161.29' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='291.72' y1='511.46' x2='329.90' y2='511.46' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='215.35' y1='511.46' x2='177.16' y2='511.46' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='291.72,530.14 215.35,530.14 215.35,492.77 291.72,492.77 291.72,530.14 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='253.53' y1='530.14' x2='253.53' y2='492.77' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='191.04' y1='461.63' x2='194.66' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='183.79' y1='461.63' x2='180.17' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='191.04,480.32 183.79,480.32 183.79,442.95 191.04,442.95 191.04,480.32 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='187.42' y1='480.32' x2='187.42' y2='442.95' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='166.86' y1='411.81' x2='172.92' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='154.75' y1='411.81' x2='148.69' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='166.86,430.49 154.75,430.49 154.75,393.12 166.86,393.12 166.86,430.49 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='160.81' y1='430.49' x2='160.81' y2='393.12' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='135.22' y1='361.98' x2='141.18' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='123.31' y1='361.98' x2='117.35' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='135.22,380.67 123.31,380.67 123.31,343.30 135.22,343.30 135.22,380.67 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='129.26' y1='380.67' x2='129.26' y2='343.30' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='140.15' y1='312.16' x2='143.39' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='133.67' y1='312.16' x2='130.43' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='140.15,330.84 133.67,330.84 133.67,293.47 140.15,293.47 140.15,330.84 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='136.91' y1='330.84' x2='136.91' y2='293.47' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='154.47' y1='262.33' x2='165.38' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='132.63' y1='262.33' x2='121.72' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='154.47,281.02 132.63,281.02 132.63,243.65 154.47,243.65 154.47,281.02 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='143.55' y1='281.02' x2='143.55' y2='243.65' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='145.92' y1='212.51' x2='154.98' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='127.78' y1='212.51' x2='118.72' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='145.92,231.19 127.78,231.19 127.78,193.82 145.92,193.82 145.92,231.19 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='136.85' y1='231.19' x2='136.85' y2='193.82' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='126.92' y1='162.68' x2='131.26' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='118.24' y1='162.68' x2='113.89' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='126.92,181.37 118.24,181.37 118.24,144.00 126.92,144.00 126.92,181.37 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='122.58' y1='181.37' x2='122.58' y2='144.00' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='154.04' y1='112.86' x2='161.31' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
 <line x1='139.51' y1='112.86' x2='132.25' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='154.03,131.54 139.51,131.54 139.51,94.18 154.03,94.18 154.03,131.54 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='146.77' y1='131.54' x2='146.77' y2='94.18' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='125.62' y1='63.04' x2='126.89' y2='63.04' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<line x1='123.08' y1='63.04' x2='121.80' y2='63.04' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<polygon points='125.62,81.72 123.08,81.72 123.08,44.35 125.62,44.35 125.62,81.72 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
-<line x1='124.35' y1='81.72' x2='124.35' y2='44.35' style='stroke-width: 3.41; stroke-linecap: butt;' />
-<polygon points='270.43,55.02 277.37,67.04 263.48,67.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<polygon points='283.95,109.82 286.58,114.38 281.32,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='299.53,159.64 302.16,164.20 296.90,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='317.69,209.47 320.33,214.03 315.06,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='339.19,259.29 341.82,263.85 336.56,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='367.78,309.12 370.41,313.68 365.15,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='400.70,358.94 403.33,363.50 398.07,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='443.74,408.77 446.37,413.33 441.11,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='506.48,458.59 509.11,463.15 503.85,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='154.04,131.54 139.51,131.54 139.51,94.18 154.04,94.18 154.04,131.54 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='146.78' y1='131.54' x2='146.78' y2='94.18' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='125.59' y1='63.04' x2='126.86' y2='63.04' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<line x1='123.04' y1='63.04' x2='121.77' y2='63.04' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<polygon points='125.59,81.72 123.04,81.72 123.04,44.35 125.59,44.35 125.59,81.72 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
+<line x1='124.31' y1='81.72' x2='124.31' y2='44.35' style='stroke-width: 3.41; stroke-linecap: butt;' />
+<polygon points='270.40,55.02 277.35,67.04 263.46,67.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='284.07,109.82 286.71,114.38 281.44,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='299.85,159.64 302.48,164.20 297.21,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='318.27,209.47 320.90,214.03 315.64,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='340.12,259.29 342.76,263.85 337.49,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='366.58,309.12 369.22,313.68 363.95,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='399.56,358.94 402.20,363.50 396.93,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='442.71,408.77 445.35,413.33 440.08,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='505.65,458.59 508.29,463.15 503.02,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <polygon points='685.92,508.42 688.55,512.98 683.29,512.98 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
@@ -109,11 +109,11 @@
 <text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.44/0.44/0.44</text>
 <text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.22/0.22/0.22</text>
 <text x='18.97' y='465.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.11/0.11/0.11</text>
-<text x='95.64' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='217.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='339.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='461.19' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='583.04' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='95.61' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='217.46' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='339.32' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='461.18' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='583.03' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
 <text x='704.89' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.5</text>
 <text x='399.91' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='89.37px' lengthAdjust='spacingAndGlyphs'>RGCCA criterion</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='148.08px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (tau)</text>

--- a/tests/testthat/_snaps/plot.permutation/permutation-crit.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-crit.svg
@@ -25,11 +25,11 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='156.53,541.35 156.53,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='278.39,541.35 278.39,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='400.25,541.35 400.25,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='522.11,541.35 522.11,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='643.96,541.35 643.96,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='149.14,541.35 149.14,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='272.70,541.35 272.70,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='396.26,541.35 396.26,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='519.82,541.35 519.82,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='643.38,541.35 643.38,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
@@ -40,67 +40,76 @@
 <polyline points='85.29,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='95.61,541.35 95.61,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='217.46,541.35 217.46,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='339.32,541.35 339.32,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='461.18,541.35 461.18,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='583.03,541.35 583.03,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='704.89,541.35 704.89,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='291.72' y1='511.46' x2='329.90' y2='511.46' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='215.35' y1='511.46' x2='177.16' y2='511.46' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='291.72,530.14 215.35,530.14 215.35,492.77 291.72,492.77 291.72,530.14 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='253.53' y1='530.14' x2='253.53' y2='492.77' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='191.04' y1='461.63' x2='194.66' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='183.79' y1='461.63' x2='180.17' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='191.04,480.32 183.79,480.32 183.79,442.95 191.04,442.95 191.04,480.32 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='187.42' y1='480.32' x2='187.42' y2='442.95' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='166.86' y1='411.81' x2='172.92' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='154.75' y1='411.81' x2='148.69' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='166.86,430.49 154.75,430.49 154.75,393.12 166.86,393.12 166.86,430.49 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='160.81' y1='430.49' x2='160.81' y2='393.12' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='135.22' y1='361.98' x2='141.18' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='123.31' y1='361.98' x2='117.35' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='135.22,380.67 123.31,380.67 123.31,343.30 135.22,343.30 135.22,380.67 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='129.26' y1='380.67' x2='129.26' y2='343.30' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='140.15' y1='312.16' x2='143.39' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='133.67' y1='312.16' x2='130.43' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='140.15,330.84 133.67,330.84 133.67,293.47 140.15,293.47 140.15,330.84 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='136.91' y1='330.84' x2='136.91' y2='293.47' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='154.47' y1='262.33' x2='165.38' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='132.63' y1='262.33' x2='121.72' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='154.47,281.02 132.63,281.02 132.63,243.65 154.47,243.65 154.47,281.02 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='143.55' y1='281.02' x2='143.55' y2='243.65' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='145.92' y1='212.51' x2='154.98' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='127.78' y1='212.51' x2='118.72' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='145.92,231.19 127.78,231.19 127.78,193.82 145.92,193.82 145.92,231.19 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='136.85' y1='231.19' x2='136.85' y2='193.82' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='126.92' y1='162.68' x2='131.26' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='118.24' y1='162.68' x2='113.89' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='126.92,181.37 118.24,181.37 118.24,144.00 126.92,144.00 126.92,181.37 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='122.58' y1='181.37' x2='122.58' y2='144.00' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='154.04' y1='112.86' x2='161.31' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='139.51' y1='112.86' x2='132.25' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='154.04,131.54 139.51,131.54 139.51,94.18 154.04,94.18 154.04,131.54 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='146.78' y1='131.54' x2='146.78' y2='94.18' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='125.59' y1='63.04' x2='126.86' y2='63.04' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<line x1='123.04' y1='63.04' x2='121.77' y2='63.04' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<polygon points='125.59,81.72 123.04,81.72 123.04,44.35 125.59,44.35 125.59,81.72 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
-<line x1='124.31' y1='81.72' x2='124.31' y2='44.35' style='stroke-width: 3.41; stroke-linecap: butt;' />
-<polygon points='270.40,55.02 277.35,67.04 263.46,67.04 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
-<polygon points='284.07,109.82 286.71,114.38 281.44,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='299.85,159.64 302.48,164.20 297.21,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='318.27,209.47 320.90,214.03 315.64,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='340.12,259.29 342.76,263.85 337.49,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='366.58,309.12 369.22,313.68 363.95,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='399.56,358.94 402.20,363.50 396.93,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='442.71,408.77 445.35,413.33 440.08,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='505.65,458.59 508.29,463.15 503.02,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='685.92,508.42 688.55,512.98 683.29,512.98 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polyline points='87.36,541.35 87.36,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='210.92,541.35 210.92,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='334.48,541.35 334.48,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='458.04,541.35 458.04,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='581.60,541.35 581.60,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='705.16,541.35 705.16,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='279.95' y1='511.46' x2='299.01' y2='511.46' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<line x1='257.19' y1='511.46' x2='250.80' y2='511.46' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<polygon points='279.95,530.14 257.19,530.14 257.19,492.77 279.95,492.77 279.95,530.14 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
+<line x1='276.37' y1='530.14' x2='276.37' y2='492.77' style='stroke-width: 3.41; stroke-linecap: butt;' />
+<line x1='197.83' y1='461.63' x2='230.44' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='173.62' y1='461.63' x2='164.88' y2='461.63' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='197.83,480.32 173.62,480.32 173.62,442.95 197.83,442.95 197.83,480.32 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='175.47' y1='480.32' x2='175.47' y2='442.95' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='206.08' cy='411.81' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='173.38' y1='411.81' x2='173.38' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='154.95' y1='411.81' x2='150.45' y2='411.81' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='173.38,430.49 154.95,430.49 154.95,393.12 173.38,393.12 173.38,430.49 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='155.61' y1='430.49' x2='155.61' y2='393.12' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='190.99' cy='361.98' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='158.40' y1='361.98' x2='158.40' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='142.79' y1='361.98' x2='141.53' y2='361.98' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='158.40,380.67 142.79,380.67 142.79,343.30 158.40,343.30 158.40,380.67 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='145.28' y1='380.67' x2='145.28' y2='343.30' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='180.09' cy='312.16' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='147.88' y1='312.16' x2='147.88' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='135.22' y1='312.16' x2='134.42' y2='312.16' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='147.88,330.84 135.22,330.84 135.22,293.47 147.88,293.47 147.88,330.84 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='138.08' y1='330.84' x2='138.08' y2='293.47' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='171.60' cy='262.33' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='139.96' y1='262.33' x2='139.96' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='130.44' y1='262.33' x2='128.23' y2='262.33' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='139.96,281.02 130.44,281.02 130.44,243.65 139.96,243.65 139.96,281.02 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='132.61' y1='281.02' x2='132.61' y2='243.65' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='164.70' cy='212.51' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='133.73' y1='212.51' x2='133.73' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='126.64' y1='212.51' x2='123.45' y2='212.51' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='133.73,231.19 126.64,231.19 126.64,193.82 133.73,193.82 133.73,231.19 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='128.25' y1='231.19' x2='128.25' y2='193.82' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='158.92' cy='162.68' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='128.69' y1='162.68' x2='128.69' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='123.52' y1='162.68' x2='119.63' y2='162.68' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='128.69,181.37 123.52,181.37 123.52,144.00 128.69,144.00 128.69,181.37 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='124.66' y1='181.37' x2='124.66' y2='144.00' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='153.98' cy='112.86' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='124.52' y1='112.86' x2='124.52' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='120.89' y1='112.86' x2='116.50' y2='112.86' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='124.52,131.54 120.89,131.54 120.89,94.18 124.52,94.18 124.52,131.54 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='121.64' y1='131.54' x2='121.64' y2='94.18' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<circle cx='113.89' cy='63.04' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<circle cx='149.69' cy='63.04' r='1.95' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #BEBEBE;' />
+<line x1='121.02' y1='63.04' x2='121.02' y2='63.04' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='118.65' y1='63.04' x2='118.65' y2='63.04' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='121.02,81.72 118.65,81.72 118.65,44.35 121.02,44.35 121.02,81.72 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='119.05' y1='81.72' x2='119.05' y2='44.35' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='264.60,60.00 267.23,64.56 261.97,64.56 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='278.46,109.82 281.09,114.38 275.83,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='294.45,159.64 297.09,164.20 291.82,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='313.14,209.47 315.77,214.03 310.50,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='335.29,259.29 337.93,263.85 332.66,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='362.12,309.12 364.76,313.68 359.49,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='395.56,358.94 398.20,363.50 392.93,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='439.32,408.77 441.95,413.33 436.69,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='503.14,458.59 505.77,463.15 500.50,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='685.92,503.44 692.86,515.46 678.98,515.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='18.97' y='66.14' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>1.00/1.00/1.00</text>
-<polyline points='18.97,66.89 80.36,66.89 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='18.97' y='514.89' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
+<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>1.00/1.00/1.00</text>
+<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
+<polyline points='18.97,515.31 80.36,515.31 ' style='stroke-width: 0.75; stroke: #666666;' />
 <text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.56/0.56/0.56</text>
 <text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.78/0.78/0.78</text>
 <text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.89/0.89/0.89</text>
@@ -109,15 +118,15 @@
 <text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.44/0.44/0.44</text>
 <text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.22/0.22/0.22</text>
 <text x='18.97' y='465.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.11/0.11/0.11</text>
-<text x='95.61' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='217.46' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='339.32' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='461.18' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='583.03' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='704.89' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='87.36' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='210.92' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='334.48' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='458.04' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='581.60' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='705.16' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>2.5</text>
 <text x='399.91' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='89.37px' lengthAdjust='spacingAndGlyphs'>RGCCA criterion</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='148.08px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (tau)</text>
-<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (2 runs) </text>
-<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='203.93px' lengthAdjust='spacingAndGlyphs'> Best parameters: 1.00/1.00/1.00</text>
+<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (5 runs) </text>
+<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='203.93px' lengthAdjust='spacingAndGlyphs'> Best parameters: 0.00/0.00/0.00</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.permutation/permutation-legend.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-legend.svg
@@ -44,14 +44,14 @@
 <polyline points='520.14,541.35 520.14,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='676.42,541.35 676.42,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polygon points='113.89,60.00 116.52,64.56 111.26,64.56 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='150.75,109.82 153.39,114.38 148.12,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='155.71,159.64 158.34,164.20 153.08,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='161.68,209.47 164.31,214.03 159.04,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='276.73,259.29 279.36,263.85 274.09,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='302.26,309.12 304.90,313.68 299.63,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='308.33,358.94 310.96,363.50 305.70,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='445.41,408.77 448.04,413.33 442.77,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='535.88,458.59 538.52,463.15 533.25,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='150.82,109.82 153.46,114.38 148.19,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='155.76,159.64 158.40,164.20 153.13,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='161.89,209.47 164.52,214.03 159.25,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='276.83,259.29 279.46,263.85 274.20,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='301.95,309.12 304.58,313.68 299.32,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='308.46,358.94 311.09,363.50 305.83,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='443.11,408.77 445.74,413.33 440.48,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='536.64,458.59 539.28,463.15 534.01,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <polygon points='685.92,503.44 692.86,515.46 678.98,515.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/plot.permutation/permutation-legend.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-legend.svg
@@ -25,10 +25,11 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='129.46,541.35 129.46,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='285.74,541.35 285.74,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='442.01,541.35 442.01,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='598.28,541.35 598.28,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='186.10,541.35 186.10,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='308.05,541.35 308.05,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='430.00,541.35 430.00,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='551.95,541.35 551.95,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='673.89,541.35 673.89,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
@@ -39,37 +40,39 @@
 <polyline points='85.29,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='207.60,541.35 207.60,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='363.87,541.35 363.87,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='520.14,541.35 520.14,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='676.42,541.35 676.42,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='125.12,541.35 125.12,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='247.07,541.35 247.07,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='369.02,541.35 369.02,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.97,541.35 490.97,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='612.92,541.35 612.92,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polygon points='113.89,60.00 116.52,64.56 111.26,64.56 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='150.82,109.82 153.46,114.38 148.19,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='155.76,159.64 158.40,164.20 153.13,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='161.89,209.47 164.52,214.03 159.25,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='276.83,259.29 279.46,263.85 274.20,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='301.95,309.12 304.58,313.68 299.32,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='308.46,358.94 311.09,363.50 305.83,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='443.11,408.77 445.74,413.33 440.48,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='536.64,458.59 539.28,463.15 534.01,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='125.79,109.82 128.42,114.38 123.15,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='138.74,159.64 141.38,164.20 136.11,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='152.82,209.47 155.46,214.03 150.19,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='167.99,259.29 170.62,263.85 165.35,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='183.96,309.12 186.60,313.68 181.33,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='199.88,358.94 202.51,363.50 197.25,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='213.26,408.77 215.89,413.33 210.63,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='218.09,458.59 220.73,463.15 215.46,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <polygon points='685.92,503.44 692.86,515.46 678.98,515.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
-<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>1.00/1.00/1.00</text>
+<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>1.00/1.00/1.00</text>
+<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
 <polyline points='18.97,515.31 80.36,515.31 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.78/0.78/0.78</text>
-<text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.89/0.89/0.89</text>
-<text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.56/0.56/0.56</text>
+<text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.56/0.56/0.56</text>
+<text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.78/0.78/0.78</text>
+<text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.89/0.89/0.89</text>
 <text x='18.97' y='215.94' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.67/0.67/0.67</text>
-<text x='18.97' y='365.42' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.22/0.22/0.22</text>
-<text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.33/0.33/0.33</text>
-<text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.44/0.44/0.44</text>
+<text x='18.97' y='365.42' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.33/0.33/0.33</text>
+<text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.44/0.44/0.44</text>
+<text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.22/0.22/0.22</text>
 <text x='18.97' y='465.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.11/0.11/0.11</text>
-<text x='207.60' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='363.87' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='520.14' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='676.42' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='125.12' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='247.07' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<text x='369.02' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>15.0</text>
+<text x='490.97' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>17.5</text>
+<text x='612.92' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>20.0</text>
 <text x='399.91' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='40.68px' lengthAdjust='spacingAndGlyphs'>Z-score</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='148.08px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (tau)</text>
 <text x='515.47' y='48.12' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='76.05px' lengthAdjust='spacingAndGlyphs'>Non permuted</text>
@@ -77,7 +80,7 @@
 <polygon points='524.11,78.23 526.74,82.79 521.47,82.79 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <text x='538.72' y='68.12' style='font-size: 12.00px; font-family: sans;' textLength='101.40px' lengthAdjust='spacingAndGlyphs'>Best parameter set</text>
 <text x='538.72' y='85.40' style='font-size: 12.00px; font-family: sans;' textLength='107.40px' lengthAdjust='spacingAndGlyphs'>Other parameter set</text>
-<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (2 runs) </text>
-<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='203.93px' lengthAdjust='spacingAndGlyphs'> Best parameters: 1.00/1.00/1.00</text>
+<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (5 runs) </text>
+<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='203.93px' lengthAdjust='spacingAndGlyphs'> Best parameters: 0.00/0.00/0.00</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.permutation/permutation-many-blocks.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-many-blocks.svg
@@ -25,51 +25,51 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDYuMzJ8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='175.58,541.35 175.58,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='383.98,541.35 383.98,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='592.38,541.35 592.38,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='172.28,541.35 172.28,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='382.03,541.35 382.03,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='591.78,541.35 591.78,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,105.74 714.52,105.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,226.74 714.52,226.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,347.75 714.52,347.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,468.75 714.52,468.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='71.38,541.35 71.38,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='279.78,541.35 279.78,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='488.18,541.35 488.18,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='696.57,541.35 696.57,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='115.00' y1='468.75' x2='117.78' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='109.44' y1='468.75' x2='106.66' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='115.00,514.12 109.44,514.12 109.44,423.37 115.00,423.37 115.00,514.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='112.22' y1='514.12' x2='112.22' y2='423.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='95.53' y1='347.75' x2='95.69' y2='347.75' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<line x1='95.22' y1='347.75' x2='95.07' y2='347.75' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<polygon points='95.53,393.12 95.22,393.12 95.22,302.37 95.53,302.37 95.53,393.12 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
-<line x1='95.38' y1='393.12' x2='95.38' y2='302.37' style='stroke-width: 3.41; stroke-linecap: butt;' />
-<line x1='97.75' y1='226.74' x2='99.26' y2='226.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='94.71' y1='226.74' x2='93.19' y2='226.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='97.75,272.12 94.71,272.12 94.71,181.37 97.75,181.37 97.75,272.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='96.23' y1='272.12' x2='96.23' y2='181.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='79.38' y1='105.74' x2='80.28' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='77.59' y1='105.74' x2='76.69' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='79.38,151.12 77.59,151.12 77.59,60.37 79.38,60.37 79.38,151.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='78.49' y1='151.12' x2='78.49' y2='60.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='209.11,102.70 211.74,107.26 206.48,107.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='355.99,223.70 358.62,228.26 353.35,228.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='564.38,339.73 571.32,351.76 557.44,351.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polyline points='67.41,541.35 67.41,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='277.16,541.35 277.16,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='486.91,541.35 486.91,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='696.66,541.35 696.66,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='103.78' y1='468.75' x2='106.37' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='98.59' y1='468.75' x2='96.00' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='103.78,514.12 98.59,514.12 98.59,423.37 103.78,423.37 103.78,514.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='101.18' y1='514.12' x2='101.18' y2='423.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='98.99' y1='347.75' x2='101.11' y2='347.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='94.77' y1='347.75' x2='92.65' y2='347.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='98.99,393.12 94.77,393.12 94.77,302.37 98.99,302.37 98.99,393.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='96.88' y1='393.12' x2='96.88' y2='302.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='87.85' y1='226.74' x2='88.73' y2='226.74' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<line x1='86.08' y1='226.74' x2='85.20' y2='226.74' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<polygon points='87.85,272.12 86.08,272.12 86.08,181.37 87.85,181.37 87.85,272.12 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
+<line x1='86.96' y1='272.12' x2='86.96' y2='181.37' style='stroke-width: 3.41; stroke-linecap: butt;' />
+<line x1='78.20' y1='105.74' x2='78.71' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='77.20' y1='105.74' x2='76.69' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='78.20,151.12 77.20,151.12 77.20,60.37 78.20,60.37 78.20,151.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='77.70' y1='151.12' x2='77.70' y2='60.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='206.03,102.70 208.67,107.26 203.40,107.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='353.86,218.73 360.80,230.75 346.91,230.75 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polygon points='563.60,344.71 566.24,349.27 560.97,349.27 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <polygon points='684.15,465.71 686.78,470.27 681.52,470.27 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='18.97' y='109.05' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 4</text>
 <text x='18.97' y='472.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 1</text>
-<text x='18.97' y='230.05' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 3</text>
-<text x='18.97' y='350.72' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 2</text>
-<polyline points='18.97,351.48 41.39,351.48 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='71.38' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='279.78' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='488.18' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='696.57' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='18.97' y='229.72' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 3</text>
+<polyline points='18.97,230.47 41.39,230.47 ' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='18.97' y='351.05' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 2</text>
+<text x='67.41' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='277.16' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='486.91' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='696.66' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
 <text x='380.42' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='88.70px' lengthAdjust='spacingAndGlyphs'>SGCCA criterion</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='172.76px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (sparsity)</text>
 <text x='46.32' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (2 runs) </text>
-<text x='46.32' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='147.09px' lengthAdjust='spacingAndGlyphs'> Best parameters: Set 2</text>
+<text x='46.32' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='147.09px' lengthAdjust='spacingAndGlyphs'> Best parameters: Set 3</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.permutation/permutation-many-blocks.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-many-blocks.svg
@@ -25,36 +25,36 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDYuMzJ8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='175.51,541.35 175.51,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='383.94,541.35 383.94,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='592.36,541.35 592.36,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='175.58,541.35 175.58,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='383.98,541.35 383.98,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='592.38,541.35 592.38,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,105.74 714.52,105.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,226.74 714.52,226.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,347.75 714.52,347.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='46.32,468.75 714.52,468.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='71.30,541.35 71.30,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='279.73,541.35 279.73,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='488.15,541.35 488.15,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='696.58,541.35 696.58,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='114.93' y1='468.75' x2='117.71' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='109.37' y1='468.75' x2='106.59' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='114.93,514.12 109.37,514.12 109.37,423.37 114.93,423.37 114.93,514.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='112.15' y1='514.12' x2='112.15' y2='423.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='95.37' y1='347.75' x2='95.53' y2='347.75' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<line x1='95.05' y1='347.75' x2='94.89' y2='347.75' style='stroke-width: 1.71; stroke-linecap: butt;' />
-<polygon points='95.37,393.12 95.05,393.12 95.05,302.37 95.37,302.37 95.37,393.12 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
-<line x1='95.21' y1='393.12' x2='95.21' y2='302.37' style='stroke-width: 3.41; stroke-linecap: butt;' />
-<line x1='97.51' y1='226.74' x2='98.94' y2='226.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='94.66' y1='226.74' x2='93.24' y2='226.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='97.51,272.12 94.66,272.12 94.66,181.37 97.51,181.37 97.51,272.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='96.09' y1='272.12' x2='96.09' y2='181.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='79.42' y1='105.74' x2='80.33' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<line x1='77.60' y1='105.74' x2='76.69' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='79.42,151.12 77.60,151.12 77.60,60.37 79.42,60.37 79.42,151.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
-<line x1='78.51' y1='151.12' x2='78.51' y2='60.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
-<polygon points='211.09,102.70 213.73,107.26 208.46,107.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='355.34,223.70 357.97,228.26 352.71,228.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='561.28,339.73 568.22,351.76 554.34,351.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
+<polyline points='71.38,541.35 71.38,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='279.78,541.35 279.78,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='488.18,541.35 488.18,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='696.57,541.35 696.57,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='115.00' y1='468.75' x2='117.78' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='109.44' y1='468.75' x2='106.66' y2='468.75' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='115.00,514.12 109.44,514.12 109.44,423.37 115.00,423.37 115.00,514.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='112.22' y1='514.12' x2='112.22' y2='423.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='95.53' y1='347.75' x2='95.69' y2='347.75' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<line x1='95.22' y1='347.75' x2='95.07' y2='347.75' style='stroke-width: 1.71; stroke-linecap: butt;' />
+<polygon points='95.53,393.12 95.22,393.12 95.22,302.37 95.53,302.37 95.53,393.12 ' style='stroke-width: 1.71; fill: #FFFFFF;' />
+<line x1='95.38' y1='393.12' x2='95.38' y2='302.37' style='stroke-width: 3.41; stroke-linecap: butt;' />
+<line x1='97.75' y1='226.74' x2='99.26' y2='226.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='94.71' y1='226.74' x2='93.19' y2='226.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='97.75,272.12 94.71,272.12 94.71,181.37 97.75,181.37 97.75,272.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='96.23' y1='272.12' x2='96.23' y2='181.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='79.38' y1='105.74' x2='80.28' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<line x1='77.59' y1='105.74' x2='76.69' y2='105.74' style='stroke-width: 1.71; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='79.38,151.12 77.59,151.12 77.59,60.37 79.38,60.37 79.38,151.12 ' style='stroke-width: 1.71; stroke: #BEBEBE; fill: #FFFFFF;' />
+<line x1='78.49' y1='151.12' x2='78.49' y2='60.37' style='stroke-width: 3.41; stroke: #BEBEBE; stroke-linecap: butt;' />
+<polygon points='209.11,102.70 211.74,107.26 206.48,107.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='355.99,223.70 358.62,228.26 353.35,228.26 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='564.38,339.73 571.32,351.76 557.44,351.76 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
 <polygon points='684.15,465.71 686.78,470.27 681.52,470.27 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
@@ -63,10 +63,10 @@
 <text x='18.97' y='230.05' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 3</text>
 <text x='18.97' y='350.72' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='22.42px' lengthAdjust='spacingAndGlyphs'>Set 2</text>
 <polyline points='18.97,351.48 41.39,351.48 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='71.30' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='279.73' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='488.15' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='696.58' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='71.38' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='279.78' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='488.18' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='696.57' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
 <text x='380.42' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='88.70px' lengthAdjust='spacingAndGlyphs'>SGCCA criterion</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='172.76px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (sparsity)</text>
 <text x='46.32' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (2 runs) </text>

--- a/tests/testthat/_snaps/plot.permutation/permutation-zstat.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-zstat.svg
@@ -25,10 +25,11 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpODUuMjl8NzE0LjUyfDMzLjE0fDU0MS4zNQ==)'>
-<polyline points='129.46,541.35 129.46,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='285.74,541.35 285.74,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='442.01,541.35 442.01,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='598.28,541.35 598.28,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='186.10,541.35 186.10,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='308.05,541.35 308.05,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='430.00,541.35 430.00,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='551.95,541.35 551.95,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='673.89,541.35 673.89,33.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,63.04 714.52,63.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,112.86 714.52,112.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,162.68 714.52,162.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
@@ -39,40 +40,42 @@
 <polyline points='85.29,411.81 714.52,411.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,461.63 714.52,461.63 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='85.29,511.46 714.52,511.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='207.60,541.35 207.60,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='363.87,541.35 363.87,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='520.14,541.35 520.14,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='676.42,541.35 676.42,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='125.12,541.35 125.12,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='247.07,541.35 247.07,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='369.02,541.35 369.02,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='490.97,541.35 490.97,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='612.92,541.35 612.92,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polygon points='113.89,60.00 116.52,64.56 111.26,64.56 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='150.82,109.82 153.46,114.38 148.19,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='155.76,159.64 158.40,164.20 153.13,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='161.89,209.47 164.52,214.03 159.25,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='276.83,259.29 279.46,263.85 274.20,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='301.95,309.12 304.58,313.68 299.32,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='308.46,358.94 311.09,363.50 305.83,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='443.11,408.77 445.74,413.33 440.48,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='536.64,458.59 539.28,463.15 534.01,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='125.79,109.82 128.42,114.38 123.15,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='138.74,159.64 141.38,164.20 136.11,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='152.82,209.47 155.46,214.03 150.19,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='167.99,259.29 170.62,263.85 165.35,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='183.96,309.12 186.60,313.68 181.33,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='199.88,358.94 202.51,363.50 197.25,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='213.26,408.77 215.89,413.33 210.63,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='218.09,458.59 220.73,463.15 215.46,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <polygon points='685.92,503.44 692.86,515.46 678.98,515.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
-<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>1.00/1.00/1.00</text>
+<text x='18.97' y='66.47' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>1.00/1.00/1.00</text>
+<text x='18.97' y='514.56' style='font-size: 9.60px; font-weight: bold; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.00/0.00/0.00</text>
 <polyline points='18.97,515.31 80.36,515.31 ' style='stroke-width: 0.75; stroke: #666666;' />
-<text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.78/0.78/0.78</text>
-<text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.89/0.89/0.89</text>
-<text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.56/0.56/0.56</text>
+<text x='18.97' y='265.77' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.56/0.56/0.56</text>
+<text x='18.97' y='166.12' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.78/0.78/0.78</text>
+<text x='18.97' y='116.29' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.89/0.89/0.89</text>
 <text x='18.97' y='215.94' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.67/0.67/0.67</text>
-<text x='18.97' y='365.42' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.22/0.22/0.22</text>
-<text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.33/0.33/0.33</text>
-<text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.44/0.44/0.44</text>
+<text x='18.97' y='365.42' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.33/0.33/0.33</text>
+<text x='18.97' y='315.59' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.44/0.44/0.44</text>
+<text x='18.97' y='415.24' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.22/0.22/0.22</text>
 <text x='18.97' y='465.06' style='font-size: 9.60px; fill: #666666; font-family: sans;' textLength='61.39px' lengthAdjust='spacingAndGlyphs'>0.11/0.11/0.11</text>
-<text x='207.60' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='363.87' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='520.14' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='676.42' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='125.12' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='247.07' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<text x='369.02' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>15.0</text>
+<text x='490.97' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>17.5</text>
+<text x='612.92' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='23.36px' lengthAdjust='spacingAndGlyphs'>20.0</text>
 <text x='399.91' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='40.68px' lengthAdjust='spacingAndGlyphs'>Z-score</text>
 <text transform='translate(13.74,287.25) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='148.08px' lengthAdjust='spacingAndGlyphs'>Tuning parameter sets (tau)</text>
-<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (2 runs) </text>
-<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='203.93px' lengthAdjust='spacingAndGlyphs'> Best parameters: 1.00/1.00/1.00</text>
+<text x='85.29' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='176.65px' lengthAdjust='spacingAndGlyphs'>Permutation scores (5 runs) </text>
+<text x='85.29' y='30.23' style='font-size: 14.00px; font-family: sans;' textLength='203.93px' lengthAdjust='spacingAndGlyphs'> Best parameters: 0.00/0.00/0.00</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.permutation/permutation-zstat.svg
+++ b/tests/testthat/_snaps/plot.permutation/permutation-zstat.svg
@@ -44,14 +44,14 @@
 <polyline points='520.14,541.35 520.14,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='676.42,541.35 676.42,33.14 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polygon points='113.89,60.00 116.52,64.56 111.26,64.56 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='150.75,109.82 153.39,114.38 148.12,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='155.71,159.64 158.34,164.20 153.08,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='161.68,209.47 164.31,214.03 159.04,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='276.73,259.29 279.36,263.85 274.09,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='302.26,309.12 304.90,313.68 299.63,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='308.33,358.94 310.96,363.50 305.70,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='445.41,408.77 448.04,413.33 442.77,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
-<polygon points='535.88,458.59 538.52,463.15 533.25,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='150.82,109.82 153.46,114.38 148.19,114.38 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='155.76,159.64 158.40,164.20 153.13,164.20 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='161.89,209.47 164.52,214.03 159.25,214.03 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='276.83,259.29 279.46,263.85 274.20,263.85 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='301.95,309.12 304.58,313.68 299.32,313.68 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='308.46,358.94 311.09,363.50 305.83,363.50 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='443.11,408.77 445.74,413.33 440.48,413.33 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
+<polygon points='536.64,458.59 539.28,463.15 534.01,463.15 ' style='stroke-width: 0.71; stroke: #BEBEBE; fill: none;' />
 <polygon points='685.92,503.44 692.86,515.46 678.98,515.46 ' style='stroke-width: 0.71; stroke: none; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/plot.rgcca/rgcca-both-2.svg
+++ b/tests/testthat/_snaps/plot.rgcca/rgcca-both-2.svg
@@ -20,166 +20,309 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMC4wMHwzNjAuMDB8MC4wMHw1NzYuMDA='>
-    <rect x='0.000000000000025' y='0.00' width='360.00' height='576.00' />
+  <clipPath id='cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw'>
+    <rect x='0.000000000000025' y='15.46' width='360.00' height='560.54' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHwzNjAuMDB8MC4wMHw1NzYuMDA=)'>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzQuNTd8MzU0LjUyfDE4LjAyfDU0MS4zNQ=='>
-    <rect x='34.57' y='18.02' width='319.95' height='523.33' />
+  <clipPath id='cpMzQuNTd8MzU0LjUyfDMzLjQ4fDU0MS4zNQ=='>
+    <rect x='34.57' y='33.48' width='319.95' height='507.87' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzQuNTd8MzU0LjUyfDE4LjAyfDU0MS4zNQ==)'>
-<polyline points='34.57,449.24 354.52,449.24 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,294.37 354.52,294.37 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,139.49 354.52,139.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='47.15,541.35 47.15,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='110.33,541.35 110.33,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='173.52,541.35 173.52,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='236.70,541.35 236.70,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='299.89,541.35 299.89,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,526.68 354.52,526.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,371.81 354.52,371.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,216.93 354.52,216.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,62.06 354.52,62.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='78.74,541.35 78.74,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='141.92,541.35 141.92,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='205.11,541.35 205.11,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='268.29,541.35 268.29,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='331.48,541.35 331.48,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='205.11' y1='541.35' x2='205.11' y2='18.02' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<line x1='34.57' y1='216.93' x2='354.52' y2='216.93' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<rect x='207.34' y='248.52' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='121.22' y='182.03' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='197.90' y='229.83' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='75.62' y='207.11' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='325.90' y='264.96' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='242.60' y='307.50' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='59.28' y='166.24' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='237.10' y='299.66' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='234.03' y='287.92' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='238.85' y='285.05' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='259.28' y='127.78' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='87.24' y='240.61' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='283.27' y='174.96' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='286.45' y='166.22' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='293.95' y='210.10' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='284.64' y='163.16' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='171.16' y='206.68' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='150.01' y='190.61' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='297.88' y='189.01' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='233.39' y='310.44' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='294.25' y='212.20' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='199.60' y='495.78' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='302.31' y='203.59' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='136.43' y='299.26' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='204.08' y='242.88' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='185.85' y='308.92' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='298.90' y='248.58' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='103.39' y='222.33' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='89.13' y='236.03' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='109.43' y='192.43' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='278.56' y='164.70' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='113.62' y='235.11' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='260.40' y='133.44' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='296.72' y='199.77' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='257.44' y='198.47' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='213.08' y='112.88' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='285.42' y='219.69' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='274.83' y='159.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='81.54' y='198.78' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='59.44' y='188.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='275.79' y='214.65' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='71.91' y='162.28' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='75.35' y='125.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='159.69' y='293.36' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='249.72' y='59.68' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='152.70' y='163.30' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='231.56' y='153.45' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<g clip-path='url(#cpMzQuNTd8MzU0LjUyfDMzLjQ4fDU0MS4zNQ==)'>
+<polyline points='34.57,451.96 354.52,451.96 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,301.66 354.52,301.66 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,151.36 354.52,151.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='47.15,541.35 47.15,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='110.33,541.35 110.33,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='173.52,541.35 173.52,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='236.70,541.35 236.70,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='299.89,541.35 299.89,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,527.11 354.52,527.11 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,376.81 354.52,376.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,226.51 354.52,226.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,76.21 354.52,76.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='78.74,541.35 78.74,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='141.92,541.35 141.92,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='205.11,541.35 205.11,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='268.29,541.35 268.29,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='331.48,541.35 331.48,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='205.11' y1='541.35' x2='205.11' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='34.57' y1='226.51' x2='354.52' y2='226.51' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='207.34' y='257.11' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='121.22' y='192.59' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='197.90' y='238.97' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='75.62' y='216.93' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='325.90' y='273.07' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='242.60' y='314.35' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='59.28' y='177.26' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='237.10' y='306.74' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='234.03' y='295.35' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='238.85' y='292.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='259.28' y='139.94' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='87.24' y='249.44' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='283.27' y='185.73' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='286.45' y='177.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='293.95' y='219.82' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='284.64' y='174.27' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='171.16' y='216.51' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='150.01' y='200.91' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='297.88' y='199.36' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='233.39' y='317.21' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='294.25' y='221.86' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='199.60' y='497.07' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='302.31' y='213.51' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='136.43' y='306.35' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='204.08' y='251.64' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='185.85' y='315.73' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='298.90' y='257.17' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='103.39' y='231.70' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='89.13' y='244.99' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='109.43' y='202.68' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='278.56' y='175.76' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='113.62' y='244.10' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='260.40' y='145.43' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='296.72' y='209.80' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='257.44' y='208.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='213.08' y='125.48' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='285.42' y='229.14' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='274.83' y='170.48' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='81.54' y='208.84' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='59.44' y='199.20' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='275.79' y='224.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='71.91' y='173.42' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='75.35' y='138.07' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='159.69' y='300.63' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='249.72' y='73.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='152.70' y='174.41' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='231.56' y='164.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='29.64' y='530.81' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
-<text x='29.64' y='375.94' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
-<text x='29.64' y='221.06' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='29.64' y='66.19' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='29.64' y='531.24' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='29.64' y='380.94' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='29.64' y='230.64' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='29.64' y='80.34' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='78.74' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
 <text x='141.92' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
 <text x='205.11' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
 <text x='268.29' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='331.48' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
 <text x='194.55' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (49.7%)</text>
-<text transform='translate(13.74,279.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='84.04px' lengthAdjust='spacingAndGlyphs'>Comp. 4 (5.8%)</text>
-<text x='34.57' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='164.24px' lengthAdjust='spacingAndGlyphs'>Sample space: superblock</text>
+<text transform='translate(13.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='84.04px' lengthAdjust='spacingAndGlyphs'>Comp. 4 (5.8%)</text>
+<text x='34.57' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='164.24px' lengthAdjust='spacingAndGlyphs'>Sample space: superblock</text>
 </g>
 <defs>
-  <clipPath id='cpMzYwLjAwfDcyMC4wMHwwLjAwfDU3Ni4wMA=='>
-    <rect x='360.00' y='0.00' width='360.00' height='576.00' />
+  <clipPath id='cpMzYwLjAwfDcyMC4wMHwxNS40Nnw1NzYuMDA='>
+    <rect x='360.00' y='15.46' width='360.00' height='560.54' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzYwLjAwfDcyMC4wMHwwLjAwfDU3Ni4wMA==)'>
+<g clip-path='url(#cpMzYwLjAwfDcyMC4wMHwxNS40Nnw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDA0LjU4fDYzMS43NnwxOC4wMnw1NDEuMzU='>
-    <rect x='404.58' y='18.02' width='227.18' height='523.33' />
+  <clipPath id='cpNDA0LjU4fDYzMS43NnwzMy40OHw1NDEuMzU='>
+    <rect x='404.58' y='33.48' width='227.18' height='507.87' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDA0LjU4fDYzMS43NnwxOC4wMnw1NDEuMzU=)'>
-<polyline points='404.58,443.25 631.76,443.25 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,334.21 631.76,334.21 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,225.17 631.76,225.17 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,116.12 631.76,116.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='447.13,541.35 447.13,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='494.47,541.35 494.47,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='541.81,541.35 541.81,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='589.16,541.35 589.16,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,497.77 631.76,497.77 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,388.73 631.76,388.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,279.69 631.76,279.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,170.64 631.76,170.64 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,61.60 631.76,61.60 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='423.46,541.35 423.46,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='470.80,541.35 470.80,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='518.14,541.35 518.14,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='565.49,541.35 565.49,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='612.83,541.35 612.83,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<line x1='518.14' y1='541.35' x2='518.14' y2='18.02' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<line x1='404.58' y1='279.69' x2='631.76' y2='279.69' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<rect x='564.09' y='268.24' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='570.30' y='269.74' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='517.51' y='293.59' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<circle cx='435.46' cy='197.75' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<circle cx='602.52' cy='322.55' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='437.89,308.25 440.52,312.81 435.26,312.81 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='592.95,179.35 595.58,183.91 590.31,183.91 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polyline points='612.83,279.69 612.64,265.85 612.06,252.08 611.11,238.41 609.79,224.91 608.10,211.64 606.04,198.63 603.63,185.96 600.88,173.65 597.80,161.78 594.39,150.38 590.67,139.51 586.67,129.19 582.39,119.48 577.85,110.42 573.07,102.04 568.06,94.38 562.86,87.46 557.48,81.31 551.93,75.97 546.26,71.44 540.47,67.75 534.59,64.92 528.64,62.95 522.65,61.85 516.64,61.63 510.64,62.29 504.67,63.82 498.75,66.23 492.91,69.49 487.18,73.60 481.56,78.54 476.10,84.29 470.80,90.82 465.70,98.12 460.80,106.14 456.14,114.87 451.73,124.26 447.58,134.28 443.72,144.88 440.16,156.02 436.91,167.66 433.99,179.75 431.41,192.25 429.17,205.10 427.30,218.24 425.79,231.64 424.65,245.23 423.89,258.96 423.51,272.77 423.51,286.60 423.89,300.42 424.65,314.14 425.79,327.73 427.30,341.13 429.17,354.27 431.41,367.12 433.99,379.62 436.91,391.71 440.16,403.35 443.72,414.49 447.58,425.10 451.73,435.11 456.14,444.50 460.80,453.23 465.70,461.25 470.80,468.55 476.10,475.08 481.56,480.83 487.18,485.77 492.91,489.88 498.75,493.14 504.67,495.55 510.64,497.08 516.64,497.74 522.65,497.52 528.64,496.42 534.59,494.45 540.47,491.62 546.26,487.93 551.93,483.41 557.48,478.06 562.86,471.91 568.06,464.99 573.07,457.33 577.85,448.95 582.39,439.89 586.67,430.18 590.67,419.87 594.39,408.99 597.80,397.59 600.88,385.72 603.63,373.42 606.04,360.74 608.10,347.73 609.79,334.46 611.11,320.96 612.06,307.29 612.64,293.52 612.83,279.69 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='565.49,279.69 565.39,272.77 565.10,265.88 564.63,259.05 563.97,252.30 563.12,245.66 562.09,239.16 560.89,232.82 559.51,226.67 557.97,220.73 556.27,215.03 554.41,209.60 552.41,204.44 550.27,199.58 548.00,195.05 545.60,190.86 543.10,187.03 540.50,183.57 537.81,180.50 535.04,177.83 532.20,175.56 529.31,173.72 526.36,172.30 523.39,171.32 520.40,170.77 517.39,170.66 514.39,170.99 511.41,171.75 508.45,172.96 505.53,174.59 502.66,176.64 499.85,179.11 497.12,181.99 494.47,185.25 491.92,188.90 489.47,192.91 487.14,197.28 484.94,201.97 482.86,206.98 480.93,212.28 479.15,217.85 477.53,223.67 476.07,229.72 474.77,235.97 473.66,242.39 472.72,248.97 471.97,255.66 471.40,262.46 471.02,269.32 470.83,276.23 470.83,283.15 471.02,290.05 471.40,296.91 471.97,303.71 472.72,310.41 473.66,316.98 474.77,323.40 476.07,329.65 477.53,335.70 479.15,341.52 480.93,347.09 482.86,352.39 484.94,357.40 487.14,362.09 489.47,366.46 491.92,370.47 494.47,374.12 497.12,377.39 499.85,380.26 502.66,382.73 505.53,384.78 508.45,386.41 511.41,387.62 514.39,388.38 517.39,388.71 520.40,388.60 523.39,388.05 526.36,387.07 529.31,385.65 532.20,383.81 535.04,381.55 537.81,378.87 540.50,375.80 543.10,372.34 545.60,368.51 548.00,364.32 550.27,359.79 552.41,354.93 554.41,349.78 556.27,344.34 557.97,338.64 559.51,332.70 560.89,326.55 562.09,320.21 563.12,313.71 563.97,307.07 564.63,300.32 565.10,293.49 565.39,286.60 565.49,279.69 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<g clip-path='url(#cpNDA0LjU4fDYzMS43NnwzMy40OHw1NDEuMzU=)'>
+<polyline points='404.58,446.14 631.76,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,340.32 631.76,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,234.50 631.76,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,128.68 631.76,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='447.13,541.35 447.13,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.47,541.35 494.47,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='541.81,541.35 541.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='589.16,541.35 589.16,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,499.05 631.76,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,393.23 631.76,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,287.41 631.76,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,181.59 631.76,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,75.78 631.76,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='423.46,541.35 423.46,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='470.80,541.35 470.80,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='518.14,541.35 518.14,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='565.49,541.35 565.49,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='612.83,541.35 612.83,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='518.14' y1='541.35' x2='518.14' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='404.58' y1='287.41' x2='631.76' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='564.09' y='276.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='570.30' y='277.71' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='517.51' y='300.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='435.46' cy='207.90' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='602.52' cy='329.01' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='437.89,315.04 440.52,319.60 435.26,319.60 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='592.95,189.95 595.58,194.51 590.31,194.51 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polyline points='612.83,287.41 612.64,273.99 612.06,260.62 611.11,247.36 609.79,234.26 608.10,221.38 606.04,208.76 603.63,196.45 600.88,184.52 597.80,172.99 594.39,161.93 590.67,151.38 586.67,141.37 582.39,131.95 577.85,123.15 573.07,115.02 568.06,107.58 562.86,100.86 557.48,94.90 551.93,89.71 546.26,85.32 540.47,81.74 534.59,78.99 528.64,77.08 522.65,76.01 516.64,75.80 510.64,76.44 504.67,77.93 498.75,80.26 492.91,83.43 487.18,87.42 481.56,92.21 476.10,97.79 470.80,104.13 465.70,111.21 460.80,119.00 456.14,127.47 451.73,136.58 447.58,146.30 443.72,156.59 440.16,167.40 436.91,178.70 433.99,190.44 431.41,202.56 429.17,215.03 427.30,227.79 425.79,240.79 424.65,253.98 423.89,267.30 423.51,280.70 423.51,294.13 423.89,307.53 424.65,320.85 425.79,334.04 427.30,347.04 429.17,359.80 431.41,372.27 433.99,384.39 436.91,396.13 440.16,407.43 443.72,418.24 447.58,428.53 451.73,438.25 456.14,447.36 460.80,455.83 465.70,463.62 470.80,470.70 476.10,477.04 481.56,482.62 487.18,487.41 492.91,491.40 498.75,494.57 504.67,496.90 510.64,498.39 516.64,499.03 522.65,498.81 528.64,497.75 534.59,495.84 540.47,493.09 546.26,489.51 551.93,485.12 557.48,479.93 562.86,473.97 568.06,467.25 573.07,459.81 577.85,451.68 582.39,442.88 586.67,433.46 590.67,423.45 594.39,412.90 597.80,401.84 600.88,390.31 603.63,378.38 606.04,366.07 608.10,353.45 609.79,340.57 611.11,327.47 612.06,314.21 612.64,300.84 612.83,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='565.49,287.41 565.39,280.70 565.10,274.02 564.63,267.39 563.97,260.84 563.12,254.40 562.09,248.09 560.89,241.93 559.51,235.97 557.97,230.20 556.27,224.67 554.41,219.39 552.41,214.39 550.27,209.68 548.00,205.28 545.60,201.22 543.10,197.50 540.50,194.14 537.81,191.16 535.04,188.56 532.20,186.37 529.31,184.58 526.36,183.20 523.39,182.25 520.40,181.71 517.39,181.61 514.39,181.93 511.41,182.67 508.45,183.84 505.53,185.42 502.66,187.41 499.85,189.81 497.12,192.60 494.47,195.77 491.92,199.31 489.47,203.21 487.14,207.44 484.94,212.00 482.86,216.86 480.93,222.00 479.15,227.41 477.53,233.06 476.07,238.93 474.77,244.99 473.66,251.22 472.72,257.60 471.97,264.10 471.40,270.69 471.02,277.36 470.83,284.06 470.83,290.77 471.02,297.47 471.40,304.13 471.97,310.73 472.72,317.23 473.66,323.61 474.77,329.84 476.07,335.90 477.53,341.77 479.15,347.42 480.93,352.83 482.86,357.97 484.94,362.83 487.14,367.39 489.47,371.62 491.92,375.52 494.47,379.06 497.12,382.23 499.85,385.02 502.66,387.41 505.53,389.41 508.45,390.99 511.41,392.16 514.39,392.90 517.39,393.22 520.40,393.11 523.39,392.58 526.36,391.63 529.31,390.25 532.20,388.46 535.04,386.27 537.81,383.67 540.50,380.69 543.10,377.33 545.60,373.61 548.00,369.55 550.27,365.15 552.41,360.44 554.41,355.43 556.27,350.16 557.97,344.63 559.51,338.86 560.89,332.90 562.09,326.74 563.12,320.43 563.97,313.99 564.63,307.44 565.10,300.81 565.39,294.13 565.49,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='399.65' y='501.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
-<text x='399.65' y='392.86' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
-<text x='399.65' y='283.81' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='399.65' y='174.77' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='399.65' y='65.73' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='399.65' y='503.18' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='399.65' y='397.36' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='399.65' y='291.54' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='399.65' y='185.72' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='399.65' y='79.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
 <text x='423.46' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
 <text x='470.80' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
 <text x='518.14' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='565.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='612.83' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
 <text x='518.17' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (49.7%)</text>
-<text transform='translate(373.74,279.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='84.04px' lengthAdjust='spacingAndGlyphs'>Comp. 4 (5.8%)</text>
-<text x='648.20' y='254.91' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Block</text>
-<rect x='653.33' y='268.81' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<circle cx='655.28' cy='288.05' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='655.28,302.29 657.92,306.85 652.65,306.85 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<text x='668.35' y='274.90' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>X_agric</text>
-<text x='668.35' y='292.18' style='font-size: 12.00px; font-family: sans;' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>X_ind</text>
-<text x='668.35' y='309.46' style='font-size: 12.00px; font-family: sans;' textLength='36.69px' lengthAdjust='spacingAndGlyphs'>X_polit</text>
-<text x='404.58' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='180.54px' lengthAdjust='spacingAndGlyphs'>Correlation circle: superblock</text>
+<text transform='translate(373.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='84.04px' lengthAdjust='spacingAndGlyphs'>Comp. 4 (5.8%)</text>
+<text x='648.20' y='262.63' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Block</text>
+<rect x='653.33' y='276.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='655.28' cy='295.78' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='655.28,310.02 657.92,314.58 652.65,314.58 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<text x='668.35' y='282.63' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>X_agric</text>
+<text x='668.35' y='299.91' style='font-size: 12.00px; font-family: sans;' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>X_ind</text>
+<text x='668.35' y='317.19' style='font-size: 12.00px; font-family: sans;' textLength='36.69px' lengthAdjust='spacingAndGlyphs'>X_polit</text>
+<text x='404.58' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='180.54px' lengthAdjust='spacingAndGlyphs'>Correlation circle: superblock</text>
+</g>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMzQuNTd8MzU0LjUyfDMzLjQ4fDU0MS4zNQ==)'>
+<polyline points='34.57,451.96 354.52,451.96 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,301.66 354.52,301.66 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,151.36 354.52,151.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='47.15,541.35 47.15,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='110.33,541.35 110.33,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='173.52,541.35 173.52,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='236.70,541.35 236.70,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='299.89,541.35 299.89,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,527.11 354.52,527.11 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,376.81 354.52,376.81 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,226.51 354.52,226.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,76.21 354.52,76.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='78.74,541.35 78.74,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='141.92,541.35 141.92,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='205.11,541.35 205.11,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='268.29,541.35 268.29,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='331.48,541.35 331.48,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='205.11' y1='541.35' x2='205.11' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='34.57' y1='226.51' x2='354.52' y2='226.51' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='207.34' y='257.11' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='121.22' y='192.59' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='197.90' y='238.97' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='75.62' y='216.93' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='325.90' y='273.07' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='242.60' y='314.35' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='59.28' y='177.26' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='237.10' y='306.74' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='234.03' y='295.35' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='238.85' y='292.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='259.28' y='139.94' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='87.24' y='249.44' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='283.27' y='185.73' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='286.45' y='177.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='293.95' y='219.82' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='284.64' y='174.27' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='171.16' y='216.51' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='150.01' y='200.91' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='297.88' y='199.36' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='233.39' y='317.21' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='294.25' y='221.86' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='199.60' y='497.07' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='302.31' y='213.51' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='136.43' y='306.35' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='204.08' y='251.64' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='185.85' y='315.73' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='298.90' y='257.17' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='103.39' y='231.70' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='89.13' y='244.99' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='109.43' y='202.68' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='278.56' y='175.76' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='113.62' y='244.10' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='260.40' y='145.43' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='296.72' y='209.80' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='257.44' y='208.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='213.08' y='125.48' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='285.42' y='229.14' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='274.83' y='170.48' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='81.54' y='208.84' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='59.44' y='199.20' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='275.79' y='224.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='71.91' y='173.42' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='75.35' y='138.07' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='159.69' y='300.63' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='249.72' y='73.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='152.70' y='174.41' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='231.56' y='164.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='29.64' y='531.24' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='29.64' y='380.94' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='29.64' y='230.64' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='29.64' y='80.34' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='78.74' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='141.92' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='205.11' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='268.29' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='331.48' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='194.55' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (49.7%)</text>
+<text transform='translate(13.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='84.04px' lengthAdjust='spacingAndGlyphs'>Comp. 4 (5.8%)</text>
+<text x='34.57' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='164.24px' lengthAdjust='spacingAndGlyphs'>Sample space: superblock</text>
+</g>
+<g clip-path='url(#cpMzYwLjAwfDcyMC4wMHwxNS40Nnw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNDA0LjU4fDYzMS43NnwzMy40OHw1NDEuMzU=)'>
+<polyline points='404.58,446.14 631.76,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,340.32 631.76,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,234.50 631.76,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,128.68 631.76,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='447.13,541.35 447.13,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.47,541.35 494.47,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='541.81,541.35 541.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='589.16,541.35 589.16,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,499.05 631.76,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,393.23 631.76,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,287.41 631.76,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,181.59 631.76,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,75.78 631.76,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='423.46,541.35 423.46,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='470.80,541.35 470.80,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='518.14,541.35 518.14,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='565.49,541.35 565.49,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='612.83,541.35 612.83,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='518.14' y1='541.35' x2='518.14' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='404.58' y1='287.41' x2='631.76' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='564.09' y='276.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='570.30' y='277.71' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='517.51' y='300.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='435.46' cy='207.90' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='602.52' cy='329.01' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='437.89,315.04 440.52,319.60 435.26,319.60 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='592.95,189.95 595.58,194.51 590.31,194.51 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polyline points='612.83,287.41 612.64,273.99 612.06,260.62 611.11,247.36 609.79,234.26 608.10,221.38 606.04,208.76 603.63,196.45 600.88,184.52 597.80,172.99 594.39,161.93 590.67,151.38 586.67,141.37 582.39,131.95 577.85,123.15 573.07,115.02 568.06,107.58 562.86,100.86 557.48,94.90 551.93,89.71 546.26,85.32 540.47,81.74 534.59,78.99 528.64,77.08 522.65,76.01 516.64,75.80 510.64,76.44 504.67,77.93 498.75,80.26 492.91,83.43 487.18,87.42 481.56,92.21 476.10,97.79 470.80,104.13 465.70,111.21 460.80,119.00 456.14,127.47 451.73,136.58 447.58,146.30 443.72,156.59 440.16,167.40 436.91,178.70 433.99,190.44 431.41,202.56 429.17,215.03 427.30,227.79 425.79,240.79 424.65,253.98 423.89,267.30 423.51,280.70 423.51,294.13 423.89,307.53 424.65,320.85 425.79,334.04 427.30,347.04 429.17,359.80 431.41,372.27 433.99,384.39 436.91,396.13 440.16,407.43 443.72,418.24 447.58,428.53 451.73,438.25 456.14,447.36 460.80,455.83 465.70,463.62 470.80,470.70 476.10,477.04 481.56,482.62 487.18,487.41 492.91,491.40 498.75,494.57 504.67,496.90 510.64,498.39 516.64,499.03 522.65,498.81 528.64,497.75 534.59,495.84 540.47,493.09 546.26,489.51 551.93,485.12 557.48,479.93 562.86,473.97 568.06,467.25 573.07,459.81 577.85,451.68 582.39,442.88 586.67,433.46 590.67,423.45 594.39,412.90 597.80,401.84 600.88,390.31 603.63,378.38 606.04,366.07 608.10,353.45 609.79,340.57 611.11,327.47 612.06,314.21 612.64,300.84 612.83,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='565.49,287.41 565.39,280.70 565.10,274.02 564.63,267.39 563.97,260.84 563.12,254.40 562.09,248.09 560.89,241.93 559.51,235.97 557.97,230.20 556.27,224.67 554.41,219.39 552.41,214.39 550.27,209.68 548.00,205.28 545.60,201.22 543.10,197.50 540.50,194.14 537.81,191.16 535.04,188.56 532.20,186.37 529.31,184.58 526.36,183.20 523.39,182.25 520.40,181.71 517.39,181.61 514.39,181.93 511.41,182.67 508.45,183.84 505.53,185.42 502.66,187.41 499.85,189.81 497.12,192.60 494.47,195.77 491.92,199.31 489.47,203.21 487.14,207.44 484.94,212.00 482.86,216.86 480.93,222.00 479.15,227.41 477.53,233.06 476.07,238.93 474.77,244.99 473.66,251.22 472.72,257.60 471.97,264.10 471.40,270.69 471.02,277.36 470.83,284.06 470.83,290.77 471.02,297.47 471.40,304.13 471.97,310.73 472.72,317.23 473.66,323.61 474.77,329.84 476.07,335.90 477.53,341.77 479.15,347.42 480.93,352.83 482.86,357.97 484.94,362.83 487.14,367.39 489.47,371.62 491.92,375.52 494.47,379.06 497.12,382.23 499.85,385.02 502.66,387.41 505.53,389.41 508.45,390.99 511.41,392.16 514.39,392.90 517.39,393.22 520.40,393.11 523.39,392.58 526.36,391.63 529.31,390.25 532.20,388.46 535.04,386.27 537.81,383.67 540.50,380.69 543.10,377.33 545.60,373.61 548.00,369.55 550.27,365.15 552.41,360.44 554.41,355.43 556.27,350.16 557.97,344.63 559.51,338.86 560.89,332.90 562.09,326.74 563.12,320.43 563.97,313.99 564.63,307.44 565.10,300.81 565.39,294.13 565.49,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='399.65' y='503.18' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='399.65' y='397.36' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='399.65' y='291.54' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='399.65' y='185.72' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='399.65' y='79.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='423.46' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='470.80' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='518.14' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='565.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='612.83' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='518.17' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (49.7%)</text>
+<text transform='translate(373.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='84.04px' lengthAdjust='spacingAndGlyphs'>Comp. 4 (5.8%)</text>
+<text x='648.20' y='262.63' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Block</text>
+<rect x='653.33' y='276.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='655.28' cy='295.78' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='655.28,310.02 657.92,314.58 652.65,314.58 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<text x='668.35' y='282.63' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>X_agric</text>
+<text x='668.35' y='299.91' style='font-size: 12.00px; font-family: sans;' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>X_ind</text>
+<text x='668.35' y='317.19' style='font-size: 12.00px; font-family: sans;' textLength='36.69px' lengthAdjust='spacingAndGlyphs'>X_polit</text>
+<text x='404.58' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='180.54px' lengthAdjust='spacingAndGlyphs'>Correlation circle: superblock</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.rgcca/rgcca-both.svg
+++ b/tests/testthat/_snaps/plot.rgcca/rgcca-both.svg
@@ -20,139 +20,139 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMC4wMHwzNjAuMDB8MC4wMHw1NzYuMDA='>
-    <rect x='0.00' y='0.00' width='360.00' height='576.00' />
+  <clipPath id='cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw'>
+    <rect x='0.00' y='15.46' width='360.00' height='560.54' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHwzNjAuMDB8MC4wMHw1NzYuMDA=)'>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzQuNTd8MjUxLjI0fDE4LjAyfDU0MS4zNQ=='>
-    <rect x='34.57' y='18.02' width='216.67' height='523.33' />
+  <clipPath id='cpMzQuNTd8MjUxLjI0fDMzLjQ4fDU0MS4zNQ=='>
+    <rect x='34.57' y='33.48' width='216.67' height='507.87' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzQuNTd8MjUxLjI0fDE4LjAyfDU0MS4zNQ==)'>
-<polyline points='34.57,511.64 251.24,511.64 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,338.43 251.24,338.43 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,165.21 251.24,165.21 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='62.27,541.35 62.27,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='99.93,541.35 99.93,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='137.59,541.35 137.59,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='175.25,541.35 175.25,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='212.91,541.35 212.91,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='250.57,541.35 250.57,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,425.03 251.24,425.03 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,251.82 251.24,251.82 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='34.57,78.60 251.24,78.60 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='43.44,541.35 43.44,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='81.10,541.35 81.10,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='118.76,541.35 118.76,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='156.42,541.35 156.42,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='194.08,541.35 194.08,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='231.74,541.35 231.74,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<text x='203.37' y='187.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='36.54px' lengthAdjust='spacingAndGlyphs'>Argentina</text>
-<text x='225.20' y='223.55' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='33.21px' lengthAdjust='spacingAndGlyphs'>Australia</text>
-<text x='186.36' y='298.90' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>Austria</text>
-<text x='83.68' y='55.76' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='30.84px' lengthAdjust='spacingAndGlyphs'>Belgium</text>
-<text x='219.71' y='241.83' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='25.15px' lengthAdjust='spacingAndGlyphs'>Bolivia</text>
-<text x='211.60' y='323.65' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>Brasil</text>
-<text x='72.05' y='270.90' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='29.90px' lengthAdjust='spacingAndGlyphs'>Canada</text>
-<text x='233.18' y='291.67' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='19.45px' lengthAdjust='spacingAndGlyphs'>Chile</text>
-<text x='209.38' y='293.20' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='36.06px' lengthAdjust='spacingAndGlyphs'>Colombia</text>
-<text x='227.23' y='378.20' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='39.38px' lengthAdjust='spacingAndGlyphs'>CostaRica</text>
-<text x='183.33' y='129.37' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='20.41px' lengthAdjust='spacingAndGlyphs'>Cuba</text>
-<text x='52.63' y='322.04' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='34.64px' lengthAdjust='spacingAndGlyphs'>Denmark</text>
-<text x='196.23' y='235.71' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='73.55px' lengthAdjust='spacingAndGlyphs'>DominicanRepublic</text>
-<text x='216.43' y='278.47' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Ecuador</text>
-<text x='189.15' y='293.93' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>Egypt</text>
-<text x='206.85' y='271.79' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='33.69px' lengthAdjust='spacingAndGlyphs'>Salvador</text>
-<text x='116.66' y='387.34' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='27.99px' lengthAdjust='spacingAndGlyphs'>Finland</text>
-<text x='92.60' y='152.33' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>France</text>
-<text x='216.31' y='264.27' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='41.76px' lengthAdjust='spacingAndGlyphs'>Guatemala</text>
-<text x='193.06' y='254.63' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='28.00px' lengthAdjust='spacingAndGlyphs'>Greece</text>
-<text x='185.62' y='253.43' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.02px' lengthAdjust='spacingAndGlyphs'>Honduras</text>
-<text x='78.37' y='76.04' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='18.51px' lengthAdjust='spacingAndGlyphs'>India</text>
-<text x='204.42' y='101.59' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='14.23px' lengthAdjust='spacingAndGlyphs'>Irak</text>
-<text x='114.21' y='382.28' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>Irland</text>
-<text x='194.02' y='219.32' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='15.66px' lengthAdjust='spacingAndGlyphs'>Italy</text>
-<text x='67.14' y='347.29' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='23.26px' lengthAdjust='spacingAndGlyphs'>Japan</text>
-<text x='159.02' y='302.88' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='18.03px' lengthAdjust='spacingAndGlyphs'>Libia</text>
-<text x='113.92' y='195.68' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='42.71px' lengthAdjust='spacingAndGlyphs'>Luxemburg</text>
-<text x='90.61' y='76.01' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='60.74px' lengthAdjust='spacingAndGlyphs'>TheNetherlands</text>
-<text x='176.54' y='214.67' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='47.93px' lengthAdjust='spacingAndGlyphs'>NewZealand</text>
-<text x='185.30' y='303.21' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='38.91px' lengthAdjust='spacingAndGlyphs'>Nicaragua</text>
-<text x='126.98' y='291.39' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='28.94px' lengthAdjust='spacingAndGlyphs'>Norway</text>
-<text x='172.65' y='274.25' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Panama</text>
-<text x='207.98' y='284.64' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='18.03px' lengthAdjust='spacingAndGlyphs'>Peru</text>
-<text x='96.03' y='121.06' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.01px' lengthAdjust='spacingAndGlyphs'>Philippine</text>
-<text x='57.65' y='483.62' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='26.58px' lengthAdjust='spacingAndGlyphs'>Poland</text>
-<text x='153.85' y='219.78' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='53.63px' lengthAdjust='spacingAndGlyphs'>SouthVietnam</text>
-<text x='191.41' y='158.46' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>Spain</text>
-<text x='99.90' y='191.50' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='30.85px' lengthAdjust='spacingAndGlyphs'>Sweden</text>
-<text x='56.73' y='165.17' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='44.13px' lengthAdjust='spacingAndGlyphs'>Switzerland</text>
-<text x='141.32' y='141.79' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='27.52px' lengthAdjust='spacingAndGlyphs'>Taiwan</text>
-<text x='147.77' y='128.54' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>UK</text>
-<text x='164.05' y='222.02' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='17.56px' lengthAdjust='spacingAndGlyphs'>USA</text>
-<text x='186.17' y='172.44' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>Uruguay</text>
-<text x='221.86' y='244.08' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='40.35px' lengthAdjust='spacingAndGlyphs'>Venezuela</text>
-<text x='157.48' y='341.30' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='54.56px' lengthAdjust='spacingAndGlyphs'>WestGermany</text>
-<text x='65.59' y='491.86' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='41.77px' lengthAdjust='spacingAndGlyphs'>Yugoslavia</text>
-<line x1='156.42' y1='541.35' x2='156.42' y2='18.02' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<line x1='34.57' y1='251.82' x2='251.24' y2='251.82' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<rect x='201.42' y='191.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<circle cx='225.20' cy='229.43' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<rect x='184.40' y='302.82' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<circle cx='83.68' cy='61.63' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='219.71,244.66 222.34,249.22 217.08,249.22 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<rect x='209.65' y='327.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<circle cx='72.05' cy='276.77' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<rect x='231.23' y='295.59' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='207.43' y='297.12' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='225.28' y='382.12' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polygon points='183.33,132.21 185.97,136.77 180.70,136.77 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='52.63' cy='327.91' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='196.23,238.55 198.87,243.11 193.60,243.11 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='216.43,281.31 219.06,285.87 213.80,285.87 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='189.15,296.77 191.78,301.33 186.52,301.33 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='206.85,274.62 209.49,279.18 204.22,279.18 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<rect x='114.71' y='391.26' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='90.65' y='156.25' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polygon points='216.31,267.10 218.94,271.66 213.67,271.66 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<rect x='191.10' y='258.55' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polygon points='185.62,256.27 188.26,260.83 182.99,260.83 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='78.37' cy='81.91' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='204.42,104.43 207.05,108.99 201.79,108.99 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='114.21' cy='388.16' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<rect x='192.06' y='223.24' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='65.19' y='351.21' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polygon points='159.02,305.72 161.66,310.28 156.39,310.28 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='113.92' cy='201.55' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<circle cx='90.61' cy='81.88' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<circle cx='176.54' cy='220.54' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='185.30,306.04 187.93,310.60 182.66,310.60 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='126.98' cy='297.27' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='172.65,277.09 175.28,281.65 170.02,281.65 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='207.98,287.47 210.61,292.03 205.34,292.03 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='96.03,123.90 98.67,128.46 93.40,128.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='57.65,486.45 60.28,491.01 55.01,491.01 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='153.85,222.61 156.48,227.17 151.22,227.17 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<polygon points='191.41,161.30 194.04,165.86 188.78,165.86 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='99.90' cy='197.38' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<circle cx='56.73' cy='171.04' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='141.32,144.63 143.95,149.19 138.69,149.19 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<circle cx='147.77' cy='134.42' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<circle cx='164.05' cy='227.89' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<circle cx='186.17' cy='178.32' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='221.86,246.92 224.49,251.48 219.23,251.48 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<rect x='155.52' y='345.22' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polygon points='65.59,494.70 68.22,499.26 62.95,499.26 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<g clip-path='url(#cpMzQuNTd8MjUxLjI0fDMzLjQ4fDU0MS4zNQ==)'>
+<polyline points='34.57,512.52 251.24,512.52 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,344.42 251.24,344.42 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,176.32 251.24,176.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='62.27,541.35 62.27,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='99.93,541.35 99.93,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='137.59,541.35 137.59,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='175.25,541.35 175.25,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='212.91,541.35 212.91,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='250.57,541.35 250.57,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,428.47 251.24,428.47 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,260.37 251.24,260.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,92.27 251.24,92.27 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='43.44,541.35 43.44,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='81.10,541.35 81.10,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='118.76,541.35 118.76,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='156.42,541.35 156.42,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='194.08,541.35 194.08,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='231.74,541.35 231.74,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='203.37' y='197.68' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='36.54px' lengthAdjust='spacingAndGlyphs'>Argentina</text>
+<text x='225.20' y='232.77' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='33.21px' lengthAdjust='spacingAndGlyphs'>Australia</text>
+<text x='186.36' y='305.89' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>Austria</text>
+<text x='83.68' y='69.93' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='30.84px' lengthAdjust='spacingAndGlyphs'>Belgium</text>
+<text x='219.71' y='250.50' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='25.15px' lengthAdjust='spacingAndGlyphs'>Bolivia</text>
+<text x='211.60' y='329.91' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>Brasil</text>
+<text x='72.05' y='278.71' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='29.90px' lengthAdjust='spacingAndGlyphs'>Canada</text>
+<text x='233.18' y='298.87' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='19.45px' lengthAdjust='spacingAndGlyphs'>Chile</text>
+<text x='209.38' y='300.36' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='36.06px' lengthAdjust='spacingAndGlyphs'>Colombia</text>
+<text x='227.23' y='382.84' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='39.38px' lengthAdjust='spacingAndGlyphs'>CostaRica</text>
+<text x='183.33' y='141.37' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='20.41px' lengthAdjust='spacingAndGlyphs'>Cuba</text>
+<text x='52.63' y='328.34' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='34.64px' lengthAdjust='spacingAndGlyphs'>Denmark</text>
+<text x='196.23' y='244.57' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='73.55px' lengthAdjust='spacingAndGlyphs'>DominicanRepublic</text>
+<text x='216.43' y='286.06' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Ecuador</text>
+<text x='189.15' y='301.07' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>Egypt</text>
+<text x='206.85' y='279.58' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='33.69px' lengthAdjust='spacingAndGlyphs'>Salvador</text>
+<text x='116.66' y='391.72' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='27.99px' lengthAdjust='spacingAndGlyphs'>Finland</text>
+<text x='92.60' y='163.65' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>France</text>
+<text x='216.31' y='272.28' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='41.76px' lengthAdjust='spacingAndGlyphs'>Guatemala</text>
+<text x='193.06' y='262.93' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='28.00px' lengthAdjust='spacingAndGlyphs'>Greece</text>
+<text x='185.62' y='261.76' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.02px' lengthAdjust='spacingAndGlyphs'>Honduras</text>
+<text x='78.37' y='89.61' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='18.51px' lengthAdjust='spacingAndGlyphs'>India</text>
+<text x='204.42' y='114.41' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='14.23px' lengthAdjust='spacingAndGlyphs'>Irak</text>
+<text x='114.21' y='386.81' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>Irland</text>
+<text x='194.02' y='228.66' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='15.66px' lengthAdjust='spacingAndGlyphs'>Italy</text>
+<text x='67.14' y='352.85' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='23.26px' lengthAdjust='spacingAndGlyphs'>Japan</text>
+<text x='159.02' y='309.75' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='18.03px' lengthAdjust='spacingAndGlyphs'>Libia</text>
+<text x='113.92' y='205.71' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='42.71px' lengthAdjust='spacingAndGlyphs'>Luxemburg</text>
+<text x='90.61' y='89.58' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='60.74px' lengthAdjust='spacingAndGlyphs'>TheNetherlands</text>
+<text x='176.54' y='224.14' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='47.93px' lengthAdjust='spacingAndGlyphs'>NewZealand</text>
+<text x='185.30' y='310.07' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='38.91px' lengthAdjust='spacingAndGlyphs'>Nicaragua</text>
+<text x='126.98' y='298.60' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='28.94px' lengthAdjust='spacingAndGlyphs'>Norway</text>
+<text x='172.65' y='281.97' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Panama</text>
+<text x='207.98' y='292.05' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='18.03px' lengthAdjust='spacingAndGlyphs'>Peru</text>
+<text x='96.03' y='133.30' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.01px' lengthAdjust='spacingAndGlyphs'>Philippine</text>
+<text x='57.65' y='485.15' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='26.58px' lengthAdjust='spacingAndGlyphs'>Poland</text>
+<text x='153.85' y='229.10' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='53.63px' lengthAdjust='spacingAndGlyphs'>SouthVietnam</text>
+<text x='191.41' y='169.60' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>Spain</text>
+<text x='99.90' y='201.66' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='30.85px' lengthAdjust='spacingAndGlyphs'>Sweden</text>
+<text x='56.73' y='176.11' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='44.13px' lengthAdjust='spacingAndGlyphs'>Switzerland</text>
+<text x='141.32' y='153.42' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='27.52px' lengthAdjust='spacingAndGlyphs'>Taiwan</text>
+<text x='147.77' y='140.56' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>UK</text>
+<text x='164.05' y='231.27' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='17.56px' lengthAdjust='spacingAndGlyphs'>USA</text>
+<text x='186.17' y='183.17' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>Uruguay</text>
+<text x='221.86' y='252.69' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='40.35px' lengthAdjust='spacingAndGlyphs'>Venezuela</text>
+<text x='157.48' y='347.03' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='54.56px' lengthAdjust='spacingAndGlyphs'>WestGermany</text>
+<text x='65.59' y='493.15' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='41.77px' lengthAdjust='spacingAndGlyphs'>Yugoslavia</text>
+<line x1='156.42' y1='541.35' x2='156.42' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='34.57' y1='260.37' x2='251.24' y2='260.37' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='201.42' y='201.60' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='225.20' cy='238.64' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<rect x='184.40' y='309.81' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='83.68' cy='75.80' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='219.71,253.34 222.34,257.90 217.08,257.90 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='209.65' y='333.83' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='72.05' cy='284.59' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<rect x='231.23' y='302.79' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='207.43' y='304.28' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='225.28' y='386.76' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='183.33,144.20 185.97,148.76 180.70,148.76 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='52.63' cy='334.22' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='196.23,247.40 198.87,251.96 193.60,251.96 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='216.43,288.90 219.06,293.46 213.80,293.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='189.15,303.90 191.78,308.46 186.52,308.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='206.85,282.41 209.49,286.97 204.22,286.97 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='114.71' y='395.64' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='90.65' y='167.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='216.31,275.11 218.94,279.67 213.67,279.67 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='191.10' y='266.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='185.62,264.60 188.26,269.16 182.99,269.16 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='78.37' cy='95.49' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='204.42,117.24 207.05,121.80 201.79,121.80 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='114.21' cy='392.68' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<rect x='192.06' y='232.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='65.19' y='356.77' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='159.02,312.59 161.66,317.15 156.39,317.15 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='113.92' cy='211.59' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='90.61' cy='95.45' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='176.54' cy='230.02' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='185.30,312.90 187.93,317.46 182.66,317.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='126.98' cy='304.48' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='172.65,284.80 175.28,289.36 170.02,289.36 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='207.98,294.88 210.61,299.44 205.34,299.44 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='96.03,136.14 98.67,140.70 93.40,140.70 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='57.65,487.98 60.28,492.54 55.01,492.54 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='153.85,231.93 156.48,236.49 151.22,236.49 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='191.41,172.44 194.04,177.00 188.78,177.00 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='99.90' cy='207.54' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='56.73' cy='181.98' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='141.32,156.26 143.95,160.82 138.69,160.82 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='147.77' cy='146.44' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='164.05' cy='237.15' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='186.17' cy='189.04' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='221.86,255.52 224.49,260.08 219.23,260.08 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='155.52' y='350.95' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='65.59,495.99 68.22,500.55 62.95,500.55 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='29.64' y='429.16' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
-<text x='29.64' y='255.95' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='29.64' y='82.73' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='29.64' y='432.60' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='29.64' y='264.50' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='29.64' y='96.40' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='43.44' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.5</text>
 <text x='81.10' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
 <text x='118.76' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
@@ -160,73 +160,263 @@
 <text x='194.08' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='231.74' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
 <text x='142.90' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
-<text transform='translate(13.74,279.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
-<text x='267.68' y='254.91' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='54.05px' lengthAdjust='spacingAndGlyphs'>Response</text>
-<rect x='277.06' y='268.81' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<circle cx='279.01' cy='288.05' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
-<polygon points='279.01,302.29 281.65,306.85 276.38,306.85 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
-<text x='296.33' y='274.90' style='font-size: 12.00px; font-family: sans;' textLength='48.70px' lengthAdjust='spacingAndGlyphs'>demoinst</text>
-<text x='296.33' y='292.18' style='font-size: 12.00px; font-family: sans;' textLength='52.71px' lengthAdjust='spacingAndGlyphs'>demostab</text>
-<text x='296.33' y='309.46' style='font-size: 12.00px; font-family: sans;' textLength='39.36px' lengthAdjust='spacingAndGlyphs'>dictator</text>
-<text x='34.57' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='143.99px' lengthAdjust='spacingAndGlyphs'>Sample space: X_agric</text>
+<text transform='translate(13.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
+<text x='267.68' y='262.63' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='54.05px' lengthAdjust='spacingAndGlyphs'>Response</text>
+<rect x='277.06' y='276.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='279.01' cy='295.78' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='279.01,310.02 281.65,314.58 276.38,314.58 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<text x='296.33' y='282.63' style='font-size: 12.00px; font-family: sans;' textLength='48.70px' lengthAdjust='spacingAndGlyphs'>demoinst</text>
+<text x='296.33' y='299.91' style='font-size: 12.00px; font-family: sans;' textLength='52.71px' lengthAdjust='spacingAndGlyphs'>demostab</text>
+<text x='296.33' y='317.19' style='font-size: 12.00px; font-family: sans;' textLength='39.36px' lengthAdjust='spacingAndGlyphs'>dictator</text>
+<text x='34.57' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='143.99px' lengthAdjust='spacingAndGlyphs'>Sample space: X_agric</text>
 </g>
 <defs>
-  <clipPath id='cpMzYwLjAwfDcyMC4wMHwwLjAwfDU3Ni4wMA=='>
-    <rect x='360.00' y='0.00' width='360.00' height='576.00' />
+  <clipPath id='cpMzYwLjAwfDcyMC4wMHwxNS40Nnw1NzYuMDA='>
+    <rect x='360.00' y='15.46' width='360.00' height='560.54' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzYwLjAwfDcyMC4wMHwwLjAwfDU3Ni4wMA==)'>
+<g clip-path='url(#cpMzYwLjAwfDcyMC4wMHwxNS40Nnw1NzYuMDA=)'>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDA0LjU4fDcxNC41MnwxOC4wMnw1NDEuMzU='>
-    <rect x='404.58' y='18.02' width='309.94' height='523.33' />
+  <clipPath id='cpNDA0LjU4fDcxNC41MnwzMy40OHw1NDEuMzU='>
+    <rect x='404.58' y='33.48' width='309.94' height='507.87' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDA0LjU4fDcxNC41MnwxOC4wMnw1NDEuMzU=)'>
-<polyline points='404.58,443.25 714.52,443.25 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,334.21 714.52,334.21 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,225.17 714.52,225.17 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,116.12 714.52,116.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='462.64,541.35 462.64,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='527.22,541.35 527.22,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='591.81,541.35 591.81,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='656.40,541.35 656.40,18.02 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,497.77 714.52,497.77 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,388.73 714.52,388.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,279.69 714.52,279.69 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,170.64 714.52,170.64 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,61.60 714.52,61.60 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='430.34,541.35 430.34,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='494.93,541.35 494.93,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='559.52,541.35 559.52,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='624.10,541.35 624.10,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='688.69,541.35 688.69,18.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<text x='685.65' y='249.84' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
-<text x='684.97' y='235.54' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
-<text x='597.69' y='65.59' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
-<line x1='559.52' y1='541.35' x2='559.52' y2='18.02' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<line x1='404.58' y1='279.69' x2='714.52' y2='279.69' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<rect x='683.70' y='253.75' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='683.01' y='239.46' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='595.73' y='69.51' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polyline points='688.69,279.69 688.43,265.85 687.65,252.08 686.36,238.41 684.55,224.91 682.24,211.64 679.44,198.63 676.15,185.96 672.40,173.65 668.19,161.78 663.54,150.38 658.47,139.51 653.01,129.19 647.16,119.48 640.97,110.42 634.45,102.04 627.62,94.38 620.52,87.46 613.18,81.31 605.62,75.97 597.87,71.44 589.97,67.75 581.95,64.92 573.83,62.95 565.66,61.85 557.47,61.63 549.28,62.29 541.13,63.82 533.06,66.23 525.10,69.49 517.27,73.60 509.61,78.54 502.15,84.29 494.93,90.82 487.96,98.12 481.29,106.14 474.93,114.87 468.90,124.26 463.25,134.28 457.98,144.88 453.12,156.02 448.69,167.66 444.70,179.75 441.18,192.25 438.13,205.10 435.57,218.24 433.52,231.64 431.96,245.23 430.93,258.96 430.41,272.77 430.41,286.60 430.93,300.42 431.96,314.14 433.52,327.73 435.57,341.13 438.13,354.27 441.18,367.12 444.70,379.62 448.69,391.71 453.12,403.35 457.98,414.49 463.25,425.10 468.90,435.11 474.93,444.50 481.29,453.23 487.96,461.25 494.93,468.55 502.15,475.08 509.61,480.83 517.27,485.77 525.10,489.88 533.06,493.14 541.13,495.55 549.28,497.08 557.47,497.74 565.66,497.52 573.83,496.42 581.95,494.45 589.97,491.62 597.87,487.93 605.62,483.41 613.18,478.06 620.52,471.91 627.62,464.99 634.45,457.33 640.97,448.95 647.16,439.89 653.01,430.18 658.47,419.87 663.54,408.99 668.19,397.59 672.40,385.72 676.15,373.42 679.44,360.74 682.24,347.73 684.55,334.46 686.36,320.96 687.65,307.29 688.43,293.52 688.69,279.69 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='624.10,279.69 623.97,272.77 623.58,265.88 622.94,259.05 622.03,252.30 620.88,245.66 619.48,239.16 617.83,232.82 615.96,226.67 613.85,220.73 611.53,215.03 608.99,209.60 606.26,204.44 603.34,199.58 600.24,195.05 596.98,190.86 593.57,187.03 590.02,183.57 586.35,180.50 582.57,177.83 578.69,175.56 574.74,173.72 570.73,172.30 566.68,171.32 562.59,170.77 558.49,170.66 554.40,170.99 550.33,171.75 546.29,172.96 542.31,174.59 538.39,176.64 534.56,179.11 530.84,181.99 527.22,185.25 523.74,188.90 520.40,192.91 517.22,197.28 514.21,201.97 511.38,206.98 508.75,212.28 506.32,217.85 504.10,223.67 502.11,229.72 500.35,235.97 498.82,242.39 497.55,248.97 496.52,255.66 495.74,262.46 495.22,269.32 494.96,276.23 494.96,283.15 495.22,290.05 495.74,296.91 496.52,303.71 497.55,310.41 498.82,316.98 500.35,323.40 502.11,329.65 504.10,335.70 506.32,341.52 508.75,347.09 511.38,352.39 514.21,357.40 517.22,362.09 520.40,366.46 523.74,370.47 527.22,374.12 530.84,377.39 534.56,380.26 538.39,382.73 542.31,384.78 546.29,386.41 550.33,387.62 554.40,388.38 558.49,388.71 562.59,388.60 566.68,388.05 570.73,387.07 574.74,385.65 578.69,383.81 582.57,381.55 586.35,378.87 590.02,375.80 593.57,372.34 596.98,368.51 600.24,364.32 603.34,359.79 606.26,354.93 608.99,349.78 611.53,344.34 613.85,338.64 615.96,332.70 617.83,326.55 619.48,320.21 620.88,313.71 622.03,307.07 622.94,300.32 623.58,293.49 623.97,286.60 624.10,279.69 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<g clip-path='url(#cpNDA0LjU4fDcxNC41MnwzMy40OHw1NDEuMzU=)'>
+<polyline points='404.58,446.14 714.52,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,340.32 714.52,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,234.50 714.52,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,128.68 714.52,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='462.64,541.35 462.64,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='527.22,541.35 527.22,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='591.81,541.35 591.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='656.40,541.35 656.40,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,499.05 714.52,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,393.23 714.52,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,287.41 714.52,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,181.59 714.52,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,75.78 714.52,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='430.34,541.35 430.34,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.93,541.35 494.93,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.52,541.35 559.52,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='624.10,541.35 624.10,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='688.69,541.35 688.69,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='685.65' y='258.27' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
+<text x='684.97' y='244.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
+<text x='597.69' y='79.47' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
+<line x1='559.52' y1='541.35' x2='559.52' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='404.58' y1='287.41' x2='714.52' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='683.70' y='262.19' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='683.01' y='248.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='595.73' y='83.39' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polyline points='688.69,287.41 688.43,273.99 687.65,260.62 686.36,247.36 684.55,234.26 682.24,221.38 679.44,208.76 676.15,196.45 672.40,184.52 668.19,172.99 663.54,161.93 658.47,151.38 653.01,141.37 647.16,131.95 640.97,123.15 634.45,115.02 627.62,107.58 620.52,100.86 613.18,94.90 605.62,89.71 597.87,85.32 589.97,81.74 581.95,78.99 573.83,77.08 565.66,76.01 557.47,75.80 549.28,76.44 541.13,77.93 533.06,80.26 525.10,83.43 517.27,87.42 509.61,92.21 502.15,97.79 494.93,104.13 487.96,111.21 481.29,119.00 474.93,127.47 468.90,136.58 463.25,146.30 457.98,156.59 453.12,167.40 448.69,178.70 444.70,190.44 441.18,202.56 438.13,215.03 435.57,227.79 433.52,240.79 431.96,253.98 430.93,267.30 430.41,280.70 430.41,294.13 430.93,307.53 431.96,320.85 433.52,334.04 435.57,347.04 438.13,359.80 441.18,372.27 444.70,384.39 448.69,396.13 453.12,407.43 457.98,418.24 463.25,428.53 468.90,438.25 474.93,447.36 481.29,455.83 487.96,463.62 494.93,470.70 502.15,477.04 509.61,482.62 517.27,487.41 525.10,491.40 533.06,494.57 541.13,496.90 549.28,498.39 557.47,499.03 565.66,498.81 573.83,497.75 581.95,495.84 589.97,493.09 597.87,489.51 605.62,485.12 613.18,479.93 620.52,473.97 627.62,467.25 634.45,459.81 640.97,451.68 647.16,442.88 653.01,433.46 658.47,423.45 663.54,412.90 668.19,401.84 672.40,390.31 676.15,378.38 679.44,366.07 682.24,353.45 684.55,340.57 686.36,327.47 687.65,314.21 688.43,300.84 688.69,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='624.10,287.41 623.97,280.70 623.58,274.02 622.94,267.39 622.03,260.84 620.88,254.40 619.48,248.09 617.83,241.93 615.96,235.97 613.85,230.20 611.53,224.67 608.99,219.39 606.26,214.39 603.34,209.68 600.24,205.28 596.98,201.22 593.57,197.50 590.02,194.14 586.35,191.16 582.57,188.56 578.69,186.37 574.74,184.58 570.73,183.20 566.68,182.25 562.59,181.71 558.49,181.61 554.40,181.93 550.33,182.67 546.29,183.84 542.31,185.42 538.39,187.41 534.56,189.81 530.84,192.60 527.22,195.77 523.74,199.31 520.40,203.21 517.22,207.44 514.21,212.00 511.38,216.86 508.75,222.00 506.32,227.41 504.10,233.06 502.11,238.93 500.35,244.99 498.82,251.22 497.55,257.60 496.52,264.10 495.74,270.69 495.22,277.36 494.96,284.06 494.96,290.77 495.22,297.47 495.74,304.13 496.52,310.73 497.55,317.23 498.82,323.61 500.35,329.84 502.11,335.90 504.10,341.77 506.32,347.42 508.75,352.83 511.38,357.97 514.21,362.83 517.22,367.39 520.40,371.62 523.74,375.52 527.22,379.06 530.84,382.23 534.56,385.02 538.39,387.41 542.31,389.41 546.29,390.99 550.33,392.16 554.40,392.90 558.49,393.22 562.59,393.11 566.68,392.58 570.73,391.63 574.74,390.25 578.69,388.46 582.57,386.27 586.35,383.67 590.02,380.69 593.57,377.33 596.98,373.61 600.24,369.55 603.34,365.15 606.26,360.44 608.99,355.43 611.53,350.16 613.85,344.63 615.96,338.86 617.83,332.90 619.48,326.74 620.88,320.43 622.03,313.99 622.94,307.44 623.58,300.81 623.97,294.13 624.10,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='399.65' y='501.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
-<text x='399.65' y='392.86' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
-<text x='399.65' y='283.81' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='399.65' y='174.77' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='399.65' y='65.73' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='399.65' y='503.18' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='399.65' y='397.36' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='399.65' y='291.54' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='399.65' y='185.72' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='399.65' y='79.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
 <text x='430.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
 <text x='494.93' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
 <text x='559.52' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='624.10' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='688.69' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
 <text x='559.55' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
-<text transform='translate(373.74,279.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
-<text x='404.58' y='15.11' style='font-size: 14.00px; font-family: sans;' textLength='160.30px' lengthAdjust='spacingAndGlyphs'>Correlation circle: X_agric</text>
+<text transform='translate(373.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
+<text x='404.58' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='160.30px' lengthAdjust='spacingAndGlyphs'>Correlation circle: X_agric</text>
+</g>
+<g clip-path='url(#cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMzQuNTd8MjUxLjI0fDMzLjQ4fDU0MS4zNQ==)'>
+<polyline points='34.57,512.52 251.24,512.52 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,344.42 251.24,344.42 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,176.32 251.24,176.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='62.27,541.35 62.27,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='99.93,541.35 99.93,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='137.59,541.35 137.59,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='175.25,541.35 175.25,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='212.91,541.35 212.91,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='250.57,541.35 250.57,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,428.47 251.24,428.47 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,260.37 251.24,260.37 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='34.57,92.27 251.24,92.27 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='43.44,541.35 43.44,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='81.10,541.35 81.10,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='118.76,541.35 118.76,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='156.42,541.35 156.42,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='194.08,541.35 194.08,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='231.74,541.35 231.74,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='203.37' y='197.68' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='36.54px' lengthAdjust='spacingAndGlyphs'>Argentina</text>
+<text x='225.20' y='232.77' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='33.21px' lengthAdjust='spacingAndGlyphs'>Australia</text>
+<text x='186.36' y='305.89' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>Austria</text>
+<text x='83.68' y='69.93' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='30.84px' lengthAdjust='spacingAndGlyphs'>Belgium</text>
+<text x='219.71' y='250.50' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='25.15px' lengthAdjust='spacingAndGlyphs'>Bolivia</text>
+<text x='211.60' y='329.91' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>Brasil</text>
+<text x='72.05' y='278.71' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='29.90px' lengthAdjust='spacingAndGlyphs'>Canada</text>
+<text x='233.18' y='298.87' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='19.45px' lengthAdjust='spacingAndGlyphs'>Chile</text>
+<text x='209.38' y='300.36' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='36.06px' lengthAdjust='spacingAndGlyphs'>Colombia</text>
+<text x='227.23' y='382.84' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='39.38px' lengthAdjust='spacingAndGlyphs'>CostaRica</text>
+<text x='183.33' y='141.37' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='20.41px' lengthAdjust='spacingAndGlyphs'>Cuba</text>
+<text x='52.63' y='328.34' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='34.64px' lengthAdjust='spacingAndGlyphs'>Denmark</text>
+<text x='196.23' y='244.57' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='73.55px' lengthAdjust='spacingAndGlyphs'>DominicanRepublic</text>
+<text x='216.43' y='286.06' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Ecuador</text>
+<text x='189.15' y='301.07' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>Egypt</text>
+<text x='206.85' y='279.58' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='33.69px' lengthAdjust='spacingAndGlyphs'>Salvador</text>
+<text x='116.66' y='391.72' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='27.99px' lengthAdjust='spacingAndGlyphs'>Finland</text>
+<text x='92.60' y='163.65' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>France</text>
+<text x='216.31' y='272.28' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='41.76px' lengthAdjust='spacingAndGlyphs'>Guatemala</text>
+<text x='193.06' y='262.93' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='28.00px' lengthAdjust='spacingAndGlyphs'>Greece</text>
+<text x='185.62' y='261.76' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.02px' lengthAdjust='spacingAndGlyphs'>Honduras</text>
+<text x='78.37' y='89.61' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='18.51px' lengthAdjust='spacingAndGlyphs'>India</text>
+<text x='204.42' y='114.41' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='14.23px' lengthAdjust='spacingAndGlyphs'>Irak</text>
+<text x='114.21' y='386.81' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='21.35px' lengthAdjust='spacingAndGlyphs'>Irland</text>
+<text x='194.02' y='228.66' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='15.66px' lengthAdjust='spacingAndGlyphs'>Italy</text>
+<text x='67.14' y='352.85' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='23.26px' lengthAdjust='spacingAndGlyphs'>Japan</text>
+<text x='159.02' y='309.75' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='18.03px' lengthAdjust='spacingAndGlyphs'>Libia</text>
+<text x='113.92' y='205.71' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='42.71px' lengthAdjust='spacingAndGlyphs'>Luxemburg</text>
+<text x='90.61' y='89.58' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='60.74px' lengthAdjust='spacingAndGlyphs'>TheNetherlands</text>
+<text x='176.54' y='224.14' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='47.93px' lengthAdjust='spacingAndGlyphs'>NewZealand</text>
+<text x='185.30' y='310.07' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='38.91px' lengthAdjust='spacingAndGlyphs'>Nicaragua</text>
+<text x='126.98' y='298.60' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='28.94px' lengthAdjust='spacingAndGlyphs'>Norway</text>
+<text x='172.65' y='281.97' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='31.80px' lengthAdjust='spacingAndGlyphs'>Panama</text>
+<text x='207.98' y='292.05' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='18.03px' lengthAdjust='spacingAndGlyphs'>Peru</text>
+<text x='96.03' y='133.30' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.01px' lengthAdjust='spacingAndGlyphs'>Philippine</text>
+<text x='57.65' y='485.15' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='26.58px' lengthAdjust='spacingAndGlyphs'>Poland</text>
+<text x='153.85' y='229.10' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='53.63px' lengthAdjust='spacingAndGlyphs'>SouthVietnam</text>
+<text x='191.41' y='169.60' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>Spain</text>
+<text x='99.90' y='201.66' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='30.85px' lengthAdjust='spacingAndGlyphs'>Sweden</text>
+<text x='56.73' y='176.11' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='44.13px' lengthAdjust='spacingAndGlyphs'>Switzerland</text>
+<text x='141.32' y='153.42' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='27.52px' lengthAdjust='spacingAndGlyphs'>Taiwan</text>
+<text x='147.77' y='140.56' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>UK</text>
+<text x='164.05' y='231.27' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='17.56px' lengthAdjust='spacingAndGlyphs'>USA</text>
+<text x='186.17' y='183.17' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='32.27px' lengthAdjust='spacingAndGlyphs'>Uruguay</text>
+<text x='221.86' y='252.69' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='40.35px' lengthAdjust='spacingAndGlyphs'>Venezuela</text>
+<text x='157.48' y='347.03' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='54.56px' lengthAdjust='spacingAndGlyphs'>WestGermany</text>
+<text x='65.59' y='493.15' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='41.77px' lengthAdjust='spacingAndGlyphs'>Yugoslavia</text>
+<line x1='156.42' y1='541.35' x2='156.42' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='34.57' y1='260.37' x2='251.24' y2='260.37' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='201.42' y='201.60' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='225.20' cy='238.64' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<rect x='184.40' y='309.81' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='83.68' cy='75.80' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='219.71,253.34 222.34,257.90 217.08,257.90 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='209.65' y='333.83' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='72.05' cy='284.59' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<rect x='231.23' y='302.79' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='207.43' y='304.28' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='225.28' y='386.76' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='183.33,144.20 185.97,148.76 180.70,148.76 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='52.63' cy='334.22' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='196.23,247.40 198.87,251.96 193.60,251.96 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='216.43,288.90 219.06,293.46 213.80,293.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='189.15,303.90 191.78,308.46 186.52,308.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='206.85,282.41 209.49,286.97 204.22,286.97 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='114.71' y='395.64' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='90.65' y='167.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='216.31,275.11 218.94,279.67 213.67,279.67 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='191.10' y='266.85' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='185.62,264.60 188.26,269.16 182.99,269.16 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='78.37' cy='95.49' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='204.42,117.24 207.05,121.80 201.79,121.80 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='114.21' cy='392.68' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<rect x='192.06' y='232.57' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='65.19' y='356.77' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='159.02,312.59 161.66,317.15 156.39,317.15 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='113.92' cy='211.59' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='90.61' cy='95.45' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='176.54' cy='230.02' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='185.30,312.90 187.93,317.46 182.66,317.46 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='126.98' cy='304.48' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='172.65,284.80 175.28,289.36 170.02,289.36 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='207.98,294.88 210.61,299.44 205.34,299.44 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='96.03,136.14 98.67,140.70 93.40,140.70 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='57.65,487.98 60.28,492.54 55.01,492.54 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='153.85,231.93 156.48,236.49 151.22,236.49 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='191.41,172.44 194.04,177.00 188.78,177.00 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='99.90' cy='207.54' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='56.73' cy='181.98' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='141.32,156.26 143.95,160.82 138.69,160.82 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<circle cx='147.77' cy='146.44' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='164.05' cy='237.15' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='186.17' cy='189.04' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='221.86,255.52 224.49,260.08 219.23,260.08 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<rect x='155.52' y='350.95' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polygon points='65.59,495.99 68.22,500.55 62.95,500.55 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='29.64' y='432.60' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='10.67px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='29.64' y='264.50' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='29.64' y='96.40' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='43.44' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.5</text>
+<text x='81.10' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='118.76' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='156.42' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='194.08' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='231.74' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='142.90' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
+<text transform='translate(13.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
+<text x='267.68' y='262.63' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='54.05px' lengthAdjust='spacingAndGlyphs'>Response</text>
+<rect x='277.06' y='276.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='279.01' cy='295.78' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='279.01,310.02 281.65,314.58 276.38,314.58 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<text x='296.33' y='282.63' style='font-size: 12.00px; font-family: sans;' textLength='48.70px' lengthAdjust='spacingAndGlyphs'>demoinst</text>
+<text x='296.33' y='299.91' style='font-size: 12.00px; font-family: sans;' textLength='52.71px' lengthAdjust='spacingAndGlyphs'>demostab</text>
+<text x='296.33' y='317.19' style='font-size: 12.00px; font-family: sans;' textLength='39.36px' lengthAdjust='spacingAndGlyphs'>dictator</text>
+<text x='34.57' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='143.99px' lengthAdjust='spacingAndGlyphs'>Sample space: X_agric</text>
+</g>
+<g clip-path='url(#cpMzYwLjAwfDcyMC4wMHwxNS40Nnw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<g clip-path='url(#cpNDA0LjU4fDcxNC41MnwzMy40OHw1NDEuMzU=)'>
+<polyline points='404.58,446.14 714.52,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,340.32 714.52,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,234.50 714.52,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,128.68 714.52,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='462.64,541.35 462.64,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='527.22,541.35 527.22,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='591.81,541.35 591.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='656.40,541.35 656.40,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,499.05 714.52,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,393.23 714.52,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,287.41 714.52,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,181.59 714.52,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,75.78 714.52,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='430.34,541.35 430.34,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.93,541.35 494.93,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.52,541.35 559.52,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='624.10,541.35 624.10,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='688.69,541.35 688.69,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='685.65' y='258.27' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
+<text x='684.97' y='244.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
+<text x='597.69' y='79.47' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
+<line x1='559.52' y1='541.35' x2='559.52' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='404.58' y1='287.41' x2='714.52' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='683.70' y='262.19' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='683.01' y='248.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='595.73' y='83.39' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<polyline points='688.69,287.41 688.43,273.99 687.65,260.62 686.36,247.36 684.55,234.26 682.24,221.38 679.44,208.76 676.15,196.45 672.40,184.52 668.19,172.99 663.54,161.93 658.47,151.38 653.01,141.37 647.16,131.95 640.97,123.15 634.45,115.02 627.62,107.58 620.52,100.86 613.18,94.90 605.62,89.71 597.87,85.32 589.97,81.74 581.95,78.99 573.83,77.08 565.66,76.01 557.47,75.80 549.28,76.44 541.13,77.93 533.06,80.26 525.10,83.43 517.27,87.42 509.61,92.21 502.15,97.79 494.93,104.13 487.96,111.21 481.29,119.00 474.93,127.47 468.90,136.58 463.25,146.30 457.98,156.59 453.12,167.40 448.69,178.70 444.70,190.44 441.18,202.56 438.13,215.03 435.57,227.79 433.52,240.79 431.96,253.98 430.93,267.30 430.41,280.70 430.41,294.13 430.93,307.53 431.96,320.85 433.52,334.04 435.57,347.04 438.13,359.80 441.18,372.27 444.70,384.39 448.69,396.13 453.12,407.43 457.98,418.24 463.25,428.53 468.90,438.25 474.93,447.36 481.29,455.83 487.96,463.62 494.93,470.70 502.15,477.04 509.61,482.62 517.27,487.41 525.10,491.40 533.06,494.57 541.13,496.90 549.28,498.39 557.47,499.03 565.66,498.81 573.83,497.75 581.95,495.84 589.97,493.09 597.87,489.51 605.62,485.12 613.18,479.93 620.52,473.97 627.62,467.25 634.45,459.81 640.97,451.68 647.16,442.88 653.01,433.46 658.47,423.45 663.54,412.90 668.19,401.84 672.40,390.31 676.15,378.38 679.44,366.07 682.24,353.45 684.55,340.57 686.36,327.47 687.65,314.21 688.43,300.84 688.69,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='624.10,287.41 623.97,280.70 623.58,274.02 622.94,267.39 622.03,260.84 620.88,254.40 619.48,248.09 617.83,241.93 615.96,235.97 613.85,230.20 611.53,224.67 608.99,219.39 606.26,214.39 603.34,209.68 600.24,205.28 596.98,201.22 593.57,197.50 590.02,194.14 586.35,191.16 582.57,188.56 578.69,186.37 574.74,184.58 570.73,183.20 566.68,182.25 562.59,181.71 558.49,181.61 554.40,181.93 550.33,182.67 546.29,183.84 542.31,185.42 538.39,187.41 534.56,189.81 530.84,192.60 527.22,195.77 523.74,199.31 520.40,203.21 517.22,207.44 514.21,212.00 511.38,216.86 508.75,222.00 506.32,227.41 504.10,233.06 502.11,238.93 500.35,244.99 498.82,251.22 497.55,257.60 496.52,264.10 495.74,270.69 495.22,277.36 494.96,284.06 494.96,290.77 495.22,297.47 495.74,304.13 496.52,310.73 497.55,317.23 498.82,323.61 500.35,329.84 502.11,335.90 504.10,341.77 506.32,347.42 508.75,352.83 511.38,357.97 514.21,362.83 517.22,367.39 520.40,371.62 523.74,375.52 527.22,379.06 530.84,382.23 534.56,385.02 538.39,387.41 542.31,389.41 546.29,390.99 550.33,392.16 554.40,392.90 558.49,393.22 562.59,393.11 566.68,392.58 570.73,391.63 574.74,390.25 578.69,388.46 582.57,386.27 586.35,383.67 590.02,380.69 593.57,377.33 596.98,373.61 600.24,369.55 603.34,365.15 606.26,360.44 608.99,355.43 611.53,350.16 613.85,344.63 615.96,338.86 617.83,332.90 619.48,326.74 620.88,320.43 622.03,313.99 622.94,307.44 623.58,300.81 623.97,294.13 624.10,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='399.65' y='503.18' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='399.65' y='397.36' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='399.65' y='291.54' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='399.65' y='185.72' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='399.65' y='79.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='430.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='494.93' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='559.52' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='624.10' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='688.69' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='559.55' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
+<text transform='translate(373.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
+<text x='404.58' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='160.30px' lengthAdjust='spacingAndGlyphs'>Correlation circle: X_agric</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot.rgcca/rgcca-both.svg
+++ b/tests/testthat/_snaps/plot.rgcca/rgcca-both.svg
@@ -180,39 +180,47 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDA0LjU4fDcxNC41MnwzMy40OHw1NDEuMzU='>
-    <rect x='404.58' y='33.48' width='309.94' height='507.87' />
+  <clipPath id='cpNDA0LjU4fDYzMS43NnwzMy40OHw1NDEuMzU='>
+    <rect x='404.58' y='33.48' width='227.18' height='507.87' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDA0LjU4fDcxNC41MnwzMy40OHw1NDEuMzU=)'>
-<polyline points='404.58,446.14 714.52,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,340.32 714.52,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,234.50 714.52,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,128.68 714.52,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='462.64,541.35 462.64,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='527.22,541.35 527.22,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='591.81,541.35 591.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='656.40,541.35 656.40,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,499.05 714.52,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,393.23 714.52,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,287.41 714.52,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,181.59 714.52,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,75.78 714.52,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='430.34,541.35 430.34,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='494.93,541.35 494.93,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='559.52,541.35 559.52,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='624.10,541.35 624.10,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='688.69,541.35 688.69,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<text x='685.65' y='258.27' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
-<text x='684.97' y='244.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
-<text x='597.69' y='79.47' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
-<line x1='559.52' y1='541.35' x2='559.52' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<line x1='404.58' y1='287.41' x2='714.52' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<rect x='683.70' y='262.19' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='683.01' y='248.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='595.73' y='83.39' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polyline points='688.69,287.41 688.43,273.99 687.65,260.62 686.36,247.36 684.55,234.26 682.24,221.38 679.44,208.76 676.15,196.45 672.40,184.52 668.19,172.99 663.54,161.93 658.47,151.38 653.01,141.37 647.16,131.95 640.97,123.15 634.45,115.02 627.62,107.58 620.52,100.86 613.18,94.90 605.62,89.71 597.87,85.32 589.97,81.74 581.95,78.99 573.83,77.08 565.66,76.01 557.47,75.80 549.28,76.44 541.13,77.93 533.06,80.26 525.10,83.43 517.27,87.42 509.61,92.21 502.15,97.79 494.93,104.13 487.96,111.21 481.29,119.00 474.93,127.47 468.90,136.58 463.25,146.30 457.98,156.59 453.12,167.40 448.69,178.70 444.70,190.44 441.18,202.56 438.13,215.03 435.57,227.79 433.52,240.79 431.96,253.98 430.93,267.30 430.41,280.70 430.41,294.13 430.93,307.53 431.96,320.85 433.52,334.04 435.57,347.04 438.13,359.80 441.18,372.27 444.70,384.39 448.69,396.13 453.12,407.43 457.98,418.24 463.25,428.53 468.90,438.25 474.93,447.36 481.29,455.83 487.96,463.62 494.93,470.70 502.15,477.04 509.61,482.62 517.27,487.41 525.10,491.40 533.06,494.57 541.13,496.90 549.28,498.39 557.47,499.03 565.66,498.81 573.83,497.75 581.95,495.84 589.97,493.09 597.87,489.51 605.62,485.12 613.18,479.93 620.52,473.97 627.62,467.25 634.45,459.81 640.97,451.68 647.16,442.88 653.01,433.46 658.47,423.45 663.54,412.90 668.19,401.84 672.40,390.31 676.15,378.38 679.44,366.07 682.24,353.45 684.55,340.57 686.36,327.47 687.65,314.21 688.43,300.84 688.69,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='624.10,287.41 623.97,280.70 623.58,274.02 622.94,267.39 622.03,260.84 620.88,254.40 619.48,248.09 617.83,241.93 615.96,235.97 613.85,230.20 611.53,224.67 608.99,219.39 606.26,214.39 603.34,209.68 600.24,205.28 596.98,201.22 593.57,197.50 590.02,194.14 586.35,191.16 582.57,188.56 578.69,186.37 574.74,184.58 570.73,183.20 566.68,182.25 562.59,181.71 558.49,181.61 554.40,181.93 550.33,182.67 546.29,183.84 542.31,185.42 538.39,187.41 534.56,189.81 530.84,192.60 527.22,195.77 523.74,199.31 520.40,203.21 517.22,207.44 514.21,212.00 511.38,216.86 508.75,222.00 506.32,227.41 504.10,233.06 502.11,238.93 500.35,244.99 498.82,251.22 497.55,257.60 496.52,264.10 495.74,270.69 495.22,277.36 494.96,284.06 494.96,290.77 495.22,297.47 495.74,304.13 496.52,310.73 497.55,317.23 498.82,323.61 500.35,329.84 502.11,335.90 504.10,341.77 506.32,347.42 508.75,352.83 511.38,357.97 514.21,362.83 517.22,367.39 520.40,371.62 523.74,375.52 527.22,379.06 530.84,382.23 534.56,385.02 538.39,387.41 542.31,389.41 546.29,390.99 550.33,392.16 554.40,392.90 558.49,393.22 562.59,393.11 566.68,392.58 570.73,391.63 574.74,390.25 578.69,388.46 582.57,386.27 586.35,383.67 590.02,380.69 593.57,377.33 596.98,373.61 600.24,369.55 603.34,365.15 606.26,360.44 608.99,355.43 611.53,350.16 613.85,344.63 615.96,338.86 617.83,332.90 619.48,326.74 620.88,320.43 622.03,313.99 622.94,307.44 623.58,300.81 623.97,294.13 624.10,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<g clip-path='url(#cpNDA0LjU4fDYzMS43NnwzMy40OHw1NDEuMzU=)'>
+<polyline points='404.58,446.14 631.76,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,340.32 631.76,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,234.50 631.76,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,128.68 631.76,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='447.13,541.35 447.13,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.47,541.35 494.47,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='541.81,541.35 541.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='589.16,541.35 589.16,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,499.05 631.76,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,393.23 631.76,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,287.41 631.76,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,181.59 631.76,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,75.78 631.76,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='423.46,541.35 423.46,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='470.80,541.35 470.80,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='518.14,541.35 518.14,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='565.49,541.35 565.49,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='612.83,541.35 612.83,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='610.60' y='258.27' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
+<text x='610.10' y='244.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
+<text x='546.12' y='79.47' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
+<text x='484.39' y='270.31' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='17.09px' lengthAdjust='spacingAndGlyphs'>gnpr</text>
+<text x='550.08' y='351.03' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>labo</text>
+<text x='474.77' y='211.28' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.49px' lengthAdjust='spacingAndGlyphs'>demostab</text>
+<text x='543.26' y='298.28' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='27.99px' lengthAdjust='spacingAndGlyphs'>dictator</text>
+<line x1='518.14' y1='541.35' x2='518.14' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='404.58' y1='287.41' x2='631.76' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='608.64' y='262.19' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='608.14' y='248.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='544.17' y='83.39' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='484.39' cy='276.18' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='550.08' cy='356.91' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='474.77,214.11 477.41,218.67 472.14,218.67 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='543.26,301.12 545.89,305.68 540.62,305.68 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polyline points='612.83,287.41 612.64,273.99 612.06,260.62 611.11,247.36 609.79,234.26 608.10,221.38 606.04,208.76 603.63,196.45 600.88,184.52 597.80,172.99 594.39,161.93 590.67,151.38 586.67,141.37 582.39,131.95 577.85,123.15 573.07,115.02 568.06,107.58 562.86,100.86 557.48,94.90 551.93,89.71 546.26,85.32 540.47,81.74 534.59,78.99 528.64,77.08 522.65,76.01 516.64,75.80 510.64,76.44 504.67,77.93 498.75,80.26 492.91,83.43 487.18,87.42 481.56,92.21 476.10,97.79 470.80,104.13 465.70,111.21 460.80,119.00 456.14,127.47 451.73,136.58 447.58,146.30 443.72,156.59 440.16,167.40 436.91,178.70 433.99,190.44 431.41,202.56 429.17,215.03 427.30,227.79 425.79,240.79 424.65,253.98 423.89,267.30 423.51,280.70 423.51,294.13 423.89,307.53 424.65,320.85 425.79,334.04 427.30,347.04 429.17,359.80 431.41,372.27 433.99,384.39 436.91,396.13 440.16,407.43 443.72,418.24 447.58,428.53 451.73,438.25 456.14,447.36 460.80,455.83 465.70,463.62 470.80,470.70 476.10,477.04 481.56,482.62 487.18,487.41 492.91,491.40 498.75,494.57 504.67,496.90 510.64,498.39 516.64,499.03 522.65,498.81 528.64,497.75 534.59,495.84 540.47,493.09 546.26,489.51 551.93,485.12 557.48,479.93 562.86,473.97 568.06,467.25 573.07,459.81 577.85,451.68 582.39,442.88 586.67,433.46 590.67,423.45 594.39,412.90 597.80,401.84 600.88,390.31 603.63,378.38 606.04,366.07 608.10,353.45 609.79,340.57 611.11,327.47 612.06,314.21 612.64,300.84 612.83,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='565.49,287.41 565.39,280.70 565.10,274.02 564.63,267.39 563.97,260.84 563.12,254.40 562.09,248.09 560.89,241.93 559.51,235.97 557.97,230.20 556.27,224.67 554.41,219.39 552.41,214.39 550.27,209.68 548.00,205.28 545.60,201.22 543.10,197.50 540.50,194.14 537.81,191.16 535.04,188.56 532.20,186.37 529.31,184.58 526.36,183.20 523.39,182.25 520.40,181.71 517.39,181.61 514.39,181.93 511.41,182.67 508.45,183.84 505.53,185.42 502.66,187.41 499.85,189.81 497.12,192.60 494.47,195.77 491.92,199.31 489.47,203.21 487.14,207.44 484.94,212.00 482.86,216.86 480.93,222.00 479.15,227.41 477.53,233.06 476.07,238.93 474.77,244.99 473.66,251.22 472.72,257.60 471.97,264.10 471.40,270.69 471.02,277.36 470.83,284.06 470.83,290.77 471.02,297.47 471.40,304.13 471.97,310.73 472.72,317.23 473.66,323.61 474.77,329.84 476.07,335.90 477.53,341.77 479.15,347.42 480.93,352.83 482.86,357.97 484.94,362.83 487.14,367.39 489.47,371.62 491.92,375.52 494.47,379.06 497.12,382.23 499.85,385.02 502.66,387.41 505.53,389.41 508.45,390.99 511.41,392.16 514.39,392.90 517.39,393.22 520.40,393.11 523.39,392.58 526.36,391.63 529.31,390.25 532.20,388.46 535.04,386.27 537.81,383.67 540.50,380.69 543.10,377.33 545.60,373.61 548.00,369.55 550.27,365.15 552.41,360.44 554.41,355.43 556.27,350.16 557.97,344.63 559.51,338.86 560.89,332.90 562.09,326.74 563.12,320.43 563.97,313.99 564.63,307.44 565.10,300.81 565.39,294.13 565.49,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='399.65' y='503.18' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
@@ -220,13 +228,20 @@
 <text x='399.65' y='291.54' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='399.65' y='185.72' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='399.65' y='79.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='430.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
-<text x='494.93' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
-<text x='559.52' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='624.10' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='688.69' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='559.55' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
+<text x='423.46' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='470.80' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='518.14' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='565.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='612.83' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='518.17' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
 <text transform='translate(373.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
+<text x='648.20' y='262.63' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Block</text>
+<rect x='653.33' y='276.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='655.28' cy='295.78' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='655.28,310.02 657.92,314.58 652.65,314.58 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<text x='668.35' y='282.63' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>X_agric</text>
+<text x='668.35' y='299.91' style='font-size: 12.00px; font-family: sans;' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>X_ind</text>
+<text x='668.35' y='317.19' style='font-size: 12.00px; font-family: sans;' textLength='36.69px' lengthAdjust='spacingAndGlyphs'>X_polit</text>
 <text x='404.58' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='160.30px' lengthAdjust='spacingAndGlyphs'>Correlation circle: X_agric</text>
 </g>
 <g clip-path='url(#cpMC4wMHwzNjAuMDB8MTUuNDZ8NTc2LjAw)'>
@@ -374,35 +389,43 @@
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
-<g clip-path='url(#cpNDA0LjU4fDcxNC41MnwzMy40OHw1NDEuMzU=)'>
-<polyline points='404.58,446.14 714.52,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,340.32 714.52,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,234.50 714.52,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,128.68 714.52,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='462.64,541.35 462.64,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='527.22,541.35 527.22,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='591.81,541.35 591.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='656.40,541.35 656.40,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,499.05 714.52,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,393.23 714.52,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,287.41 714.52,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,181.59 714.52,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='404.58,75.78 714.52,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='430.34,541.35 430.34,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='494.93,541.35 494.93,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='559.52,541.35 559.52,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='624.10,541.35 624.10,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='688.69,541.35 688.69,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<text x='685.65' y='258.27' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
-<text x='684.97' y='244.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
-<text x='597.69' y='79.47' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
-<line x1='559.52' y1='541.35' x2='559.52' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<line x1='404.58' y1='287.41' x2='714.52' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<rect x='683.70' y='262.19' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='683.01' y='248.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<rect x='595.73' y='83.39' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
-<polyline points='688.69,287.41 688.43,273.99 687.65,260.62 686.36,247.36 684.55,234.26 682.24,221.38 679.44,208.76 676.15,196.45 672.40,184.52 668.19,172.99 663.54,161.93 658.47,151.38 653.01,141.37 647.16,131.95 640.97,123.15 634.45,115.02 627.62,107.58 620.52,100.86 613.18,94.90 605.62,89.71 597.87,85.32 589.97,81.74 581.95,78.99 573.83,77.08 565.66,76.01 557.47,75.80 549.28,76.44 541.13,77.93 533.06,80.26 525.10,83.43 517.27,87.42 509.61,92.21 502.15,97.79 494.93,104.13 487.96,111.21 481.29,119.00 474.93,127.47 468.90,136.58 463.25,146.30 457.98,156.59 453.12,167.40 448.69,178.70 444.70,190.44 441.18,202.56 438.13,215.03 435.57,227.79 433.52,240.79 431.96,253.98 430.93,267.30 430.41,280.70 430.41,294.13 430.93,307.53 431.96,320.85 433.52,334.04 435.57,347.04 438.13,359.80 441.18,372.27 444.70,384.39 448.69,396.13 453.12,407.43 457.98,418.24 463.25,428.53 468.90,438.25 474.93,447.36 481.29,455.83 487.96,463.62 494.93,470.70 502.15,477.04 509.61,482.62 517.27,487.41 525.10,491.40 533.06,494.57 541.13,496.90 549.28,498.39 557.47,499.03 565.66,498.81 573.83,497.75 581.95,495.84 589.97,493.09 597.87,489.51 605.62,485.12 613.18,479.93 620.52,473.97 627.62,467.25 634.45,459.81 640.97,451.68 647.16,442.88 653.01,433.46 658.47,423.45 663.54,412.90 668.19,401.84 672.40,390.31 676.15,378.38 679.44,366.07 682.24,353.45 684.55,340.57 686.36,327.47 687.65,314.21 688.43,300.84 688.69,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='624.10,287.41 623.97,280.70 623.58,274.02 622.94,267.39 622.03,260.84 620.88,254.40 619.48,248.09 617.83,241.93 615.96,235.97 613.85,230.20 611.53,224.67 608.99,219.39 606.26,214.39 603.34,209.68 600.24,205.28 596.98,201.22 593.57,197.50 590.02,194.14 586.35,191.16 582.57,188.56 578.69,186.37 574.74,184.58 570.73,183.20 566.68,182.25 562.59,181.71 558.49,181.61 554.40,181.93 550.33,182.67 546.29,183.84 542.31,185.42 538.39,187.41 534.56,189.81 530.84,192.60 527.22,195.77 523.74,199.31 520.40,203.21 517.22,207.44 514.21,212.00 511.38,216.86 508.75,222.00 506.32,227.41 504.10,233.06 502.11,238.93 500.35,244.99 498.82,251.22 497.55,257.60 496.52,264.10 495.74,270.69 495.22,277.36 494.96,284.06 494.96,290.77 495.22,297.47 495.74,304.13 496.52,310.73 497.55,317.23 498.82,323.61 500.35,329.84 502.11,335.90 504.10,341.77 506.32,347.42 508.75,352.83 511.38,357.97 514.21,362.83 517.22,367.39 520.40,371.62 523.74,375.52 527.22,379.06 530.84,382.23 534.56,385.02 538.39,387.41 542.31,389.41 546.29,390.99 550.33,392.16 554.40,392.90 558.49,393.22 562.59,393.11 566.68,392.58 570.73,391.63 574.74,390.25 578.69,388.46 582.57,386.27 586.35,383.67 590.02,380.69 593.57,377.33 596.98,373.61 600.24,369.55 603.34,365.15 606.26,360.44 608.99,355.43 611.53,350.16 613.85,344.63 615.96,338.86 617.83,332.90 619.48,326.74 620.88,320.43 622.03,313.99 622.94,307.44 623.58,300.81 623.97,294.13 624.10,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<g clip-path='url(#cpNDA0LjU4fDYzMS43NnwzMy40OHw1NDEuMzU=)'>
+<polyline points='404.58,446.14 631.76,446.14 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,340.32 631.76,340.32 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,234.50 631.76,234.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,128.68 631.76,128.68 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='447.13,541.35 447.13,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='494.47,541.35 494.47,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='541.81,541.35 541.81,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='589.16,541.35 589.16,33.48 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,499.05 631.76,499.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,393.23 631.76,393.23 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,287.41 631.76,287.41 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,181.59 631.76,181.59 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='404.58,75.78 631.76,75.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='423.46,541.35 423.46,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='470.80,541.35 470.80,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='518.14,541.35 518.14,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='565.49,541.35 565.49,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='612.83,541.35 612.83,33.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='610.60' y='258.27' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='13.29px' lengthAdjust='spacingAndGlyphs'>gini</text>
+<text x='610.10' y='244.40' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='17.08px' lengthAdjust='spacingAndGlyphs'>farm</text>
+<text x='546.12' y='79.47' text-anchor='middle' style='font-size: 8.54px; fill: #999999; font-family: sans;' textLength='14.71px' lengthAdjust='spacingAndGlyphs'>rent</text>
+<text x='484.39' y='270.31' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='17.09px' lengthAdjust='spacingAndGlyphs'>gnpr</text>
+<text x='550.08' y='351.03' text-anchor='middle' style='font-size: 8.54px; fill: #E69F00; font-family: sans;' textLength='16.14px' lengthAdjust='spacingAndGlyphs'>labo</text>
+<text x='474.77' y='211.28' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='37.49px' lengthAdjust='spacingAndGlyphs'>demostab</text>
+<text x='543.26' y='298.28' text-anchor='middle' style='font-size: 8.54px; fill: #56B4E9; font-family: sans;' textLength='27.99px' lengthAdjust='spacingAndGlyphs'>dictator</text>
+<line x1='518.14' y1='541.35' x2='518.14' y2='33.48' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='404.58' y1='287.41' x2='631.76' y2='287.41' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<rect x='608.64' y='262.19' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='608.14' y='248.32' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<rect x='544.17' y='83.39' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='484.39' cy='276.18' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<circle cx='550.08' cy='356.91' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='474.77,214.11 477.41,218.67 472.14,218.67 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polygon points='543.26,301.12 545.89,305.68 540.62,305.68 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<polyline points='612.83,287.41 612.64,273.99 612.06,260.62 611.11,247.36 609.79,234.26 608.10,221.38 606.04,208.76 603.63,196.45 600.88,184.52 597.80,172.99 594.39,161.93 590.67,151.38 586.67,141.37 582.39,131.95 577.85,123.15 573.07,115.02 568.06,107.58 562.86,100.86 557.48,94.90 551.93,89.71 546.26,85.32 540.47,81.74 534.59,78.99 528.64,77.08 522.65,76.01 516.64,75.80 510.64,76.44 504.67,77.93 498.75,80.26 492.91,83.43 487.18,87.42 481.56,92.21 476.10,97.79 470.80,104.13 465.70,111.21 460.80,119.00 456.14,127.47 451.73,136.58 447.58,146.30 443.72,156.59 440.16,167.40 436.91,178.70 433.99,190.44 431.41,202.56 429.17,215.03 427.30,227.79 425.79,240.79 424.65,253.98 423.89,267.30 423.51,280.70 423.51,294.13 423.89,307.53 424.65,320.85 425.79,334.04 427.30,347.04 429.17,359.80 431.41,372.27 433.99,384.39 436.91,396.13 440.16,407.43 443.72,418.24 447.58,428.53 451.73,438.25 456.14,447.36 460.80,455.83 465.70,463.62 470.80,470.70 476.10,477.04 481.56,482.62 487.18,487.41 492.91,491.40 498.75,494.57 504.67,496.90 510.64,498.39 516.64,499.03 522.65,498.81 528.64,497.75 534.59,495.84 540.47,493.09 546.26,489.51 551.93,485.12 557.48,479.93 562.86,473.97 568.06,467.25 573.07,459.81 577.85,451.68 582.39,442.88 586.67,433.46 590.67,423.45 594.39,412.90 597.80,401.84 600.88,390.31 603.63,378.38 606.04,366.07 608.10,353.45 609.79,340.57 611.11,327.47 612.06,314.21 612.64,300.84 612.83,287.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='565.49,287.41 565.39,280.70 565.10,274.02 564.63,267.39 563.97,260.84 563.12,254.40 562.09,248.09 560.89,241.93 559.51,235.97 557.97,230.20 556.27,224.67 554.41,219.39 552.41,214.39 550.27,209.68 548.00,205.28 545.60,201.22 543.10,197.50 540.50,194.14 537.81,191.16 535.04,188.56 532.20,186.37 529.31,184.58 526.36,183.20 523.39,182.25 520.40,181.71 517.39,181.61 514.39,181.93 511.41,182.67 508.45,183.84 505.53,185.42 502.66,187.41 499.85,189.81 497.12,192.60 494.47,195.77 491.92,199.31 489.47,203.21 487.14,207.44 484.94,212.00 482.86,216.86 480.93,222.00 479.15,227.41 477.53,233.06 476.07,238.93 474.77,244.99 473.66,251.22 472.72,257.60 471.97,264.10 471.40,270.69 471.02,277.36 470.83,284.06 470.83,290.77 471.02,297.47 471.40,304.13 471.97,310.73 472.72,317.23 473.66,323.61 474.77,329.84 476.07,335.90 477.53,341.77 479.15,347.42 480.93,352.83 482.86,357.97 484.94,362.83 487.14,367.39 489.47,371.62 491.92,375.52 494.47,379.06 497.12,382.23 499.85,385.02 502.66,387.41 505.53,389.41 508.45,390.99 511.41,392.16 514.39,392.90 517.39,393.22 520.40,393.11 523.39,392.58 526.36,391.63 529.31,390.25 532.20,388.46 535.04,386.27 537.81,383.67 540.50,380.69 543.10,377.33 545.60,373.61 548.00,369.55 550.27,365.15 552.41,360.44 554.41,355.43 556.27,350.16 557.97,344.63 559.51,338.86 560.89,332.90 562.09,326.74 563.12,320.43 563.97,313.99 564.63,307.44 565.10,300.81 565.39,294.13 565.49,287.41 ' style='stroke-width: 0.64; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='399.65' y='503.18' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
@@ -410,13 +433,20 @@
 <text x='399.65' y='291.54' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='399.65' y='185.72' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='399.65' y='79.90' text-anchor='end' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='430.34' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
-<text x='494.93' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
-<text x='559.52' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='624.10' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='688.69' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='559.55' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
+<text x='423.46' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='470.80' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='518.14' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='565.49' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='612.83' y='554.54' text-anchor='middle' style='font-size: 12.00px; font-style: italic; fill: #666666; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='518.17' y='568.03' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 1 (66.1%)</text>
 <text transform='translate(373.74,287.41) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='90.71px' lengthAdjust='spacingAndGlyphs'>Comp. 2 (31.8%)</text>
+<text x='648.20' y='262.63' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Block</text>
+<rect x='653.33' y='276.54' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #999999;' />
+<circle cx='655.28' cy='295.78' r='1.95' style='stroke-width: 0.71; stroke: #E69F00;' />
+<polygon points='655.28,310.02 657.92,314.58 652.65,314.58 ' style='stroke-width: 0.71; stroke: #56B4E9; fill: none;' />
+<text x='668.35' y='282.63' style='font-size: 12.00px; font-family: sans;' textLength='40.69px' lengthAdjust='spacingAndGlyphs'>X_agric</text>
+<text x='668.35' y='299.91' style='font-size: 12.00px; font-family: sans;' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>X_ind</text>
+<text x='668.35' y='317.19' style='font-size: 12.00px; font-family: sans;' textLength='36.69px' lengthAdjust='spacingAndGlyphs'>X_polit</text>
 <text x='404.58' y='30.57' style='font-size: 14.00px; font-family: sans;' textLength='160.30px' lengthAdjust='spacingAndGlyphs'>Correlation circle: X_agric</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/print.cval.md
+++ b/tests/testthat/_snaps/print.cval.md
@@ -81,15 +81,15 @@
       
       Tuning parameters (sparsity) used: 
         agriculture industry politic
-      1        1.00     1.00    1.00
-      2        0.58     0.71    0.58
+      1       1.000    1.000   1.000
+      2       0.577    0.707   0.577
       
       Validation: loo 
       Prediction model: lm 
       
         Tuning parameters Mean MAE    Sd
-      1    1.00/1.00/1.00     0.88 0.474
-      2    0.58/0.71/0.58     0.93 0.492
+      1    1.00/1.00/1.00    0.880 0.474
+      2    0.58/0.71/0.58    0.932 0.494
       
       The best combination is: 1 1 1 for a mean MAE of 0.88 
 
@@ -113,8 +113,8 @@
       
       Tuning parameters (sparsity) used: 
         agriculture industry politic
-      1        1.00     1.00       0
-      2        0.58     0.71       0
+      1       1.000    1.000       0
+      2       0.577    0.707       0
       
       Validation: kfold with 5 folds and 1 run(s)) 
       Prediction model: lda 

--- a/tests/testthat/_snaps/print.permutation.md
+++ b/tests/testthat/_snaps/print.permutation.md
@@ -29,33 +29,36 @@
 # print.permutation prints the expected text 2
 
     Code
-      blocks2 <- c(blocks, blocks)
+      blocks2 <- rep(blocks, 3)
       names(blocks2) <- NULL
       res <- rgcca_permutation(blocks2, par_type = "ncomp", par_length = 2, n_perms = 2,
         n_cores = 1, verbose = FALSE)
       print(res)
     Output
-      Call: method='rgcca', superblock=FALSE, scale=TRUE, scale_block=TRUE, init='svd', bias=TRUE, tol=1e-08, NA_method='nipals', ncomp=c(1,1,1,1,1,1), response=NULL 
-      There are J = 6 blocks.
+      Call: method='rgcca', superblock=FALSE, scale=TRUE, scale_block=TRUE, init='svd', bias=TRUE, tol=1e-08, NA_method='nipals', ncomp=c(1,1,1,1,1,1,1,1,1), response=NULL 
+      There are J = 9 blocks.
       The design matrix is:
-             block1 block2 block3 block4 block5 block6
-      block1      0      1      1      1      1      1
-      block2      1      0      1      1      1      1
-      block3      1      1      0      1      1      1
-      block4      1      1      1      0      1      1
-      block5      1      1      1      1      0      1
-      block6      1      1      1      1      1      0
+             block1 block2 block3 block4 block5 block6 block7 block8 block9
+      block1      0      1      1      1      1      1      1      1      1
+      block2      1      0      1      1      1      1      1      1      1
+      block3      1      1      0      1      1      1      1      1      1
+      block4      1      1      1      0      1      1      1      1      1
+      block5      1      1      1      1      0      1      1      1      1
+      block6      1      1      1      1      1      0      1      1      1
+      block7      1      1      1      1      1      1      0      1      1
+      block8      1      1      1      1      1      1      1      0      1
+      block9      1      1      1      1      1      1      1      1      0
       
       The factorial scheme is used.
       
       Tuning parameters (ncomp) used: 
-        block1 block2 block3 block4 block5 block6
-      1      2      2      2      2      2      2
-      2      1      1      1      1      1      1
+        block1 block2 block3 block4 block5 block6 block7 block8 block9
+      1      2      2      2      2      2      2      2      2      2
+      2      1      1      1      1      1      1      1      1      1
       
-        Tuning parameters Criterion Permuted criterion     sd zstat p-value
-      1             Set 1      6.24              0.361 0.0365   161       0
-      2             Set 2      5.88              0.520 0.0297   181       0
+        Tuning parameters Criterion Permuted criterion    sd zstat p-value
+      1             Set 1      16.6              1.032 0.144 107.6       0
+      2             Set 2      15.6              0.953 0.258  56.6       0
       
-      The best combination is: 1, 1, 1, 1, 1, 1 for a z score of 181 and a p-value of 0.
+      The best combination is: 2, 2, 2, 2, 2, 2, 2, 2, 2 for a z score of 108 and a p-value of 0.
 

--- a/tests/testthat/_snaps/print.permutation.md
+++ b/tests/testthat/_snaps/print.permutation.md
@@ -20,11 +20,11 @@
       1           1        1       1
       2           0        0       0
       
-        Tuning parameters Criterion Permuted criterion    sd zstat p-value
-      1             1/1/1     0.717              0.150 0.058  9.77       0
-      2             0/0/0     2.422              0.783 0.162 10.12       0
+        Tuning parameters Criterion Permuted criterion     sd zstat p-value
+      1             1/1/1     0.717               0.15 0.0580  9.77       0
+      2             0/0/0     2.422               0.75 0.0778 21.50       0
       
-      The best combination is: 0, 0, 0 for a z score of 10.1 and a p-value of 0.
+      The best combination is: 0, 0, 0 for a z score of 21.5 and a p-value of 0.
 
 # print.permutation prints the expected text 2
 
@@ -57,8 +57,8 @@
       2      1      1      1      1      1      1      1      1      1
       
         Tuning parameters Criterion Permuted criterion    sd zstat p-value
-      1             Set 1      16.6              1.032 0.144 107.6       0
-      2             Set 2      15.6              0.953 0.258  56.6       0
+      1             Set 1      16.6              0.877 0.127   124       0
+      2             Set 2      15.6              0.792 0.111   133       0
       
-      The best combination is: 2, 2, 2, 2, 2, 2, 2, 2, 2 for a z score of 108 and a p-value of 0.
+      The best combination is: 1, 1, 1, 1, 1, 1, 1, 1, 1 for a z score of 133 and a p-value of 0.
 

--- a/tests/testthat/test_checks.r
+++ b/tests/testthat/test_checks.r
@@ -375,7 +375,7 @@ test_that("check_penalty raises an error if any element of sparsity is lower
   min_sparsity <- 1 / sqrt(NCOL(blocks[[3]]))
   expect_error(check_penalty(c(1, 1, 0.2), blocks, method = "sgcca"),
     paste0(
-      "too high sparsity. Sparsity parameter equals 0.2. For SGCCA, ",
+      "too low sparsity. Sparsity parameter equals 0.2. For SGCCA, ",
       "it must be greater than 1/sqrt(number_column)",
       " (i.e., ", round(min_sparsity, 4), " for block 3)."
     ),

--- a/tests/testthat/test_plot.cval.R
+++ b/tests/testthat/test_plot.cval.R
@@ -12,9 +12,7 @@ res <- rgcca_cv(blocks,
   response = 3, method = "rgcca", par_type = "tau",
   par_value = c(0, 0.2, 0.3), n_run = 1, n_cores = 1
 )
-blocks2 <- c(blocks, blocks)
-names(blocks2) <- NULL
-res2 <- suppressWarnings(rgcca_cv(blocks2,
+res2 <- suppressWarnings(rgcca_cv(blocks,
   verbose = FALSE,
   response = 3, method = "sgcca", par_type = "ncomp",
   par_length = 3, n_run = 1, n_cores = 1

--- a/tests/testthat/test_plot.permutation.r
+++ b/tests/testthat/test_plot.permutation.r
@@ -8,7 +8,7 @@ A <- list(
   politic = Russett[, 6:11]
 )
 perm.out <- rgcca_permutation(A,
-  par_type = "tau", n_perms = 2,
+  par_type = "tau", n_perms = 5,
   n_cores = 1, verbose = FALSE
 )
 

--- a/tests/testthat/test_plot.rgcca.r
+++ b/tests/testthat/test_plot.rgcca.r
@@ -21,7 +21,8 @@ test_that("plot.rgcca produces the expected sample plot", {
 test_that("plot.rgcca produces the expected correlation circle", {
   vdiffr::expect_doppelganger(
     "RGCCA cor_circle", plot.rgcca(
-      fit.rgcca, type = "cor_circle", block = 2, comp = seq(2)
+      fit.rgcca, type = "cor_circle", block = 2,
+      comp = seq(2), display_blocks = 2
     )
   )
 })

--- a/tests/testthat/test_print.permutation.R
+++ b/tests/testthat/test_print.permutation.R
@@ -22,7 +22,7 @@ test_that("print.permutation prints the expected text", {
 test_that("print.permutation prints the expected text 2", {
   local_edition(3)
   expect_snapshot({
-    blocks2 <- c(blocks, blocks)
+    blocks2 <- rep(blocks, 3)
     names(blocks2) <- NULL
     res <- rgcca_permutation(blocks2,
       par_type = "ncomp", par_length = 2,

--- a/tests/testthat/test_rgcca_bootstrap_k.r
+++ b/tests/testthat/test_rgcca_bootstrap_k.r
@@ -44,9 +44,5 @@ inds <- c(2, 2:NROW(blocks_3$agriculture))
 resb_3 <- rgcca_bootstrap_k(rgcca_res = rgcca_out_3, inds = inds)
 
 test_that("test_rgcca_bootstrap_k_missing_var_identification", {
-  expect_is(resb_3, "list")
-  expect_is(resb_3[[1]], "character")
-  expect_is(resb_3[[2]], "character")
-  expect_equal(resb_3[[1]], "rent")
-  expect_equal(resb_3[[2]], "rent")
+  expect_null(resb_3)
 })

--- a/tests/testthat/test_rgcca_permutation_k.R
+++ b/tests/testthat/test_rgcca_permutation_k.R
@@ -8,17 +8,20 @@ res_rgcca <- rgcca(blocks)
 res_sgcca <- rgcca(blocks, method = "sgcca", sparsity = c(.75, .8))
 res_rgcca2 <- rgcca(blocks, ncomp = 2)
 res_sgcca2 <- rgcca(blocks, ncomp = 2, method = "sgcca", sparsity = c(.75, .8))
+inds <- lapply(blocks, function(x) {
+  sample(NROW(x))
+})
 
 test_that("rgcca_permutation_k gives the same criterion as rgcca if perm
           is FALSE", {
   res_perm <- rgcca_permutation_k(
-    res_rgcca$call, perm = FALSE, par_type = "tau",
+    res_rgcca$call, inds, perm = FALSE, par_type = "tau",
     par_value = rep(1, length(blocks))
   )
   expect_equal(res_perm, res_rgcca$crit[length(res_rgcca$crit)])
 
   res_perm <- rgcca_permutation_k(
-    res_rgcca2$call, perm = FALSE, par_type = "tau",
+    res_rgcca2$call, inds, perm = FALSE, par_type = "tau",
     par_value = rep(1, length(blocks))
   )
   crit <- sum(vapply(
@@ -31,13 +34,13 @@ test_that("rgcca_permutation_k gives the same criterion as rgcca if perm
 test_that("rgcca_permutation_k gives a smaller criterion than rgcca if perm
           is TRUE", {
   res_perm <- rgcca_permutation_k(
-    res_rgcca$call, perm = TRUE, par_type = "tau",
+    res_rgcca$call, inds, perm = TRUE, par_type = "tau",
     par_value = rep(1, length(blocks))
   )
   expect_lt(res_perm, res_rgcca$crit[length(res_rgcca$crit)])
 
   res_perm <- rgcca_permutation_k(
-    res_rgcca2$call, perm = TRUE, par_type = "tau",
+    res_rgcca2$call, inds, perm = TRUE, par_type = "tau",
     par_value = rep(1, length(blocks))
   )
   crit <- sum(vapply(
@@ -50,12 +53,14 @@ test_that("rgcca_permutation_k gives a smaller criterion than rgcca if perm
 test_that("rgcca_permutation_k gives the same criterion as sgcca if perm
           is FALSE", {
   res_perm <- rgcca_permutation_k(
-    res_sgcca$call, perm = FALSE, par_type = "sparsity", par_value = c(.75, .8)
+    res_sgcca$call, inds, perm = FALSE,
+    par_type = "sparsity", par_value = c(.75, .8)
   )
   expect_equal(res_perm, res_sgcca$crit[length(res_sgcca$crit)])
 
   res_perm <- rgcca_permutation_k(
-    res_sgcca2$call, perm = FALSE, par_type = "sparsity", par_value = c(.75, .8)
+    res_sgcca2$call, inds, perm = FALSE,
+    par_type = "sparsity", par_value = c(.75, .8)
   )
   crit <- sum(vapply(
     res_sgcca2$crit, function(x) x[length(x)],
@@ -67,12 +72,14 @@ test_that("rgcca_permutation_k gives the same criterion as sgcca if perm
 test_that("rgcca_permutation_k gives a smaller criterion than sgcca if perm
           is TRUE", {
   res_perm <- rgcca_permutation_k(
-    res_sgcca$call, perm = TRUE, par_type = "sparsity", par_value = c(.75, .8)
+    res_sgcca$call, inds, perm = TRUE,
+    par_type = "sparsity", par_value = c(.75, .8)
   )
   expect_lt(res_perm, res_sgcca$crit[length(res_sgcca$crit)])
 
   res_perm <- rgcca_permutation_k(
-    res_sgcca2$call, perm = TRUE, par_type = "sparsity", par_value = c(.75, .8)
+    res_sgcca2$call, inds, perm = TRUE,
+    par_type = "sparsity", par_value = c(.75, .8)
   )
   crit <- sum(vapply(
     res_sgcca2$crit, function(x) x[length(x)],

--- a/tests/testthat/test_set_parameter_grid.R
+++ b/tests/testthat/test_set_parameter_grid.R
@@ -80,7 +80,7 @@ test_that("set_parameter_grid returns a valid grid of parameters when par_value
 
   tau <- matrix(c(.001, .002, 1, 1, 1, 1), nrow = 2, ncol = 3)
   res <- set_parameter_grid("tau", 2, tau, blocks, response = 3)
-  test_tau(res, 1)
+  test_tau(res, 2)
 
   sparsity <- matrix(c(
     0.6, 0.8, 1,


### PR DESCRIPTION
Make some fixes to handle data with missing values better:
- Define as a constant column a column where there is only one non-missing value.
- Change to `NULL` the value returned by `rgcca_bootstrap_k` for a bootstrap sample with a constant column in at least one block.

Add some functionalities for the correlation circle plots: 
- Add a new argument, `display_blocks`, which allows choosing which variables are plotted against the components of the selected block used to draw the correlation circle.
- Forbid drawing a correlation circle with non-orthogonal components. If there is a superblock, the components of the superblock are used, whatever the original value of the `block` argument. If there is a response block, and `block` corresponds to this response block, an error is thrown.

Additional fixes: 
- Remove rounding of tuning parameters and change the strategy to replace long parameter combinations with set numbers.
- Change `rgcca_permutation` to make the comparisons on the same permutations.