### PR TITLE
Add probs as output of rgcca_predict

### DIFF
--- a/R/rgcca_predict.R
+++ b/R/rgcca_predict.R
@@ -24,6 +24,10 @@
 #' block is missing.}
 #' @return \item{model}{A list of the models trained using caret to make the
 #' predictions and compute the scores.}
+#' @return \item{probs}{A list of data.frames with the class probabilities
+#' of the test and train response blocks predicted by the prediction
+#' model. If the prediction model does not compute class probabilities, the
+#' data.frames are empty.}
 #' @return \item{metric}{A list of data.frames containing the scores obtained
 #' on the training and testing sets.}
 #' @return \item{confusion}{A list containing NA for regression tasks.

--- a/man/rgcca_predict.Rd
+++ b/man/rgcca_predict.Rd
@@ -43,6 +43,11 @@ block is missing.}
 \item{model}{A list of the models trained using caret to make the
 predictions and compute the scores.}
 
+\item{probs}{A list of data.frames with the class probabilities
+of the test and train response blocks predicted by the prediction
+model. If the prediction model does not compute class probabilities, the
+data.frames are empty.}
+
 \item{metric}{A list of data.frames containing the scores obtained
 on the training and testing sets.}
 

--- a/tests/testthat/test_rgcca_predict.r
+++ b/tests/testthat/test_rgcca_predict.r
@@ -90,6 +90,12 @@ test_that("rgcca_predict with lm predictor gives the same prediction as
   expect_equal(as.matrix(A[[response]] - res_predict$prediction$test), res_lm)
 })
 
+test_that("rgcca_predict returns an empty probs in regression", {
+  res_predict <- rgcca_predict(rgcca_res = fit_rgcca)
+  expect_equal(nrow(res_predict$probs$train), 0)
+  expect_equal(nrow(res_predict$probs$test), 0)
+})
+
 # Classification
 #---------------
 test_that("rgcca_predict with lda predictor gives the same prediction as
@@ -108,4 +114,17 @@ test_that("rgcca_predict with lda predictor gives the same prediction as
     res_predict$prediction$test,
     data.frame(politic = prediction_lda)
   )
+})
+
+test_that("rgcca_predict returns probs in classification with adequate model", {
+  A <- lapply(blocks_classif, function(x) x[1:32, ])
+  B <- lapply(blocks_classif, function(x) x[33:47, ])
+  response <- 3
+  fit_rgcca <- rgcca(A, tau = 1, ncomp = c(3, 2, 1), response = response)
+  res_predict <- rgcca_predict(fit_rgcca,
+                               blocks_test = B[-3],
+                               prediction_model = "lda"
+  )
+  expect_equal(nrow(res_predict$probs$train), 32)
+  expect_equal(nrow(res_predict$probs$test), 15)
 })


### PR DESCRIPTION
Add a new output to rgcca_predict: `probs` contains the probabilities predicted by the underlying classification model used in the function. The returned data frame is empty if the classification model does not predict probabilities.

Related to #79 